### PR TITLE
Use machine for build & test and capture build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,13 @@ jobs:
       - run:
           name: Build and run tests
           command: |
-            ./gradlew --no-daemon build
+            ./gradlew --no-daemon build test shadowJar
 
       - store_test_results:
           path: build/test-results/test
+
+      - store_artifacts:
+          path: build/libs
 
 workflows:
   version: 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
         kotlinOptions.jvmTarget = "1.8"
     }
 
-    // Output to build/libs/shadow.jar
+    // Output to build/libs/liquibase-shadow.jar
     //
     // This jar can be used directly as a library in the liquibase
     // dependency. It includes everything needed to run with Cloud Spanner
@@ -85,8 +85,7 @@ tasks {
     //
     shadowJar {
         dependsOn("test")
-        baseName = "shadow"
-        //mergeServiceFiles()
+        baseName = "liquibase-shadow"
         dependencies {
             exclude(dependency("org.liquibase:liquibase-core"))
         }


### PR DESCRIPTION
Changes -
- Use machine for build & test. This is needed for docker and Java test containers.
- Capture test results and built artifacts
- Rename shadowJar to be liquibase-shadow.
