### PR TITLE
test: use mock server for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
     <liquibase.version>3.8.9</liquibase.version>
 
+    <gax-grpc.version>1.60.0</gax-grpc.version>
     <jupiter.version>5.6.2</jupiter.version>
     <testcontainers.version>1.13.0</testcontainers.version>
     <truth.version>1.0.1</truth.version>
@@ -52,7 +53,7 @@
       <artifactId>google-cloud-spanner-jdbc</artifactId>
     </dependency>
 
-    <!-- Test dependencies -->
+    <!-- Generic test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -65,6 +66,20 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>${truth.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    
+    <!-- Spanner test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
@@ -87,17 +102,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <version>${truth.version}</version>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+      <version>${gax-grpc.version}</version>
+      <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
+    
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
+++ b/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
@@ -1,0 +1,126 @@
+package liquibase.ext.spanner;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.admin.database.v1.MockDatabaseAdminImpl;
+import com.google.cloud.spanner.connection.ConnectionOptions;
+import com.google.common.collect.ImmutableList;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import com.google.spanner.v1.StructType.Field;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+public abstract class AbstractMockServerTest {
+  static final Statement SELECT_FROM_DATABASECHANGELOG = Statement.of("SELECT * FROM DATABASECHANGELOG ORDER BY DATEEXECUTED ASC, ORDEREXECUTED ASC");
+  static final Statement SELECT_COUNT_FROM_DATABASECHANGELOG = Statement.of("SELECT COUNT(*) FROM DATABASECHANGELOG");
+  private static final ResultSetMetadata COUNT_METADATA =
+      ResultSetMetadata.newBuilder()
+          .setRowType(
+              StructType.newBuilder()
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("C")
+                          .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                          .build())
+                  .build())
+          .build();
+  
+  protected static final String DB_ID = "projects/p/instances/i/databases/d";
+  protected static MockSpannerServiceImpl mockSpanner;
+  protected static MockDatabaseAdminImpl mockAdmin;
+  private static Server server;
+  private static InetSocketAddress address;
+
+  @BeforeAll
+  static void startStaticServer() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockAdmin = new MockDatabaseAdminImpl();
+    address = new InetSocketAddress("localhost", 0);
+    server = NettyServerBuilder.forAddress(address).addService(mockSpanner).addService(mockAdmin).build().start();
+  }
+
+  @AfterAll
+  static void stopServer() throws Exception {
+    // Make sure to close all connections before we stop the mock server.
+    ConnectionOptions.closeSpanner();
+    server.shutdown();
+    server.awaitTermination();
+  }
+  
+  static ResultSet createCountResultSet(long count) {
+    return
+        com.google.spanner.v1.ResultSet.newBuilder()
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(
+                        Value.newBuilder()
+                            .setStringValue(String.valueOf(count))
+                            .build())
+                    .build())
+            .setMetadata(COUNT_METADATA)
+            .build();
+  }
+  
+  static Liquibase getLiquibase(Connection connection, String changeLogFile) throws DatabaseException {
+    Liquibase liquibase = new Liquibase(
+        changeLogFile,
+        new ClassLoaderResourceAccessor(),
+    DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+       new JdbcConnection(connection)
+    ));
+    return liquibase;
+  }
+  
+  static void addUpdateDdlStatementsResponse(String statement) {
+    addUpdateDdlStatementsResponse(ImmutableList.of(statement));
+  }
+  
+  static void addUpdateDdlStatementsResponse(Iterable<String> statements) {
+    mockAdmin.addResponse(Operation.newBuilder()
+        .setDone(true)
+        .setMetadata(Any.pack(UpdateDatabaseDdlMetadata.newBuilder()
+            .addAllCommitTimestamps(ImmutableList.of(Timestamp.now().toProto()))
+            .setDatabase(DB_ID)
+            .addAllStatements(statements)
+            .build()))
+        .setName(String.format("%s/operations/o", DB_ID))
+        .setResponse(Any.pack(Empty.getDefaultInstance()))
+        .build()
+        );
+  }
+  
+  static Iterable<String> getUpdateDdlStatementsList(int index) {
+    return ((UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(index)).getStatementsList();
+  }
+  
+  static Connection createConnection() throws SQLException {
+    StringBuilder url = new StringBuilder("jdbc:cloudspanner://localhost:")
+        .append(server.getPort())
+        .append("/projects/p/instances/i/databases/d;usePlainText=true");
+    return DriverManager.getConnection(url.toString());
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/DatabaseChangeLog.java
+++ b/src/test/java/liquibase/ext/spanner/DatabaseChangeLog.java
@@ -1,0 +1,139 @@
+package liquibase.ext.spanner;
+
+import com.google.cloud.Timestamp;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Value;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import com.google.spanner.v1.StructType.Field;
+
+class DatabaseChangeLog {
+  String id;
+  String author;
+  String filename;
+  Timestamp dateExecuted;
+  long orderExecuted;
+  String execType;
+  String md5;
+  String description;
+  String comments;
+  String tag;
+  String liquibase;
+  String contexts;
+  String labels;
+  String deploymentId;
+  
+  static final ResultSetMetadata DATABASECHANGELOG_METADATA =
+      ResultSetMetadata.newBuilder()
+          .setRowType(
+              StructType.newBuilder()
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("ID")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("AUTHOR")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("FILENAME")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("DATEEXECUTED")
+                          .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("ORDEREXECUTED")
+                          .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("EXECTYPE")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("MD5SUM")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("DESCRIPTION")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("COMMENTS")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("TAG")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("LIQUIBASE")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("CONTEXTS")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("LABELS")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("DEPLOYMENT_ID")
+                          .setType(Type.newBuilder().setCode(TypeCode.STRING).build())
+                          .build())
+                  .build())
+          .build();
+
+  static ResultSet createChangeSetResultSet(Iterable<DatabaseChangeLog> rows) {
+    ResultSet.Builder builder = ResultSet.newBuilder().setMetadata(DATABASECHANGELOG_METADATA);
+    for (DatabaseChangeLog row : rows) {
+      builder.addRows(ListValue.newBuilder()
+          .addValues(createStringOrNullValue(row.id))
+          .addValues(createStringOrNullValue(row.author))
+          .addValues(createStringOrNullValue(row.filename))
+          .addValues(createStringOrNullValue(row.dateExecuted.toString()))
+          .addValues(createStringOrNullValue(String.valueOf(row.orderExecuted)))
+          .addValues(createStringOrNullValue(row.execType))
+          .addValues(createStringOrNullValue(row.md5))
+          .addValues(createStringOrNullValue(row.description))
+          .addValues(createStringOrNullValue(row.comments))
+          .addValues(createStringOrNullValue(row.tag))
+          .addValues(createStringOrNullValue(row.liquibase))
+          .addValues(createStringOrNullValue(row.contexts))
+          .addValues(createStringOrNullValue(row.labels))
+          .addValues(createStringOrNullValue(row.deploymentId))
+          );
+    }
+    return builder.build();
+  }
+  
+  static Value createStringOrNullValue(String val) {
+    Value.Builder builder = Value.newBuilder();
+    if (val == null) {
+      builder.setNullValue(NullValue.NULL_VALUE);
+    } else {
+      builder.setStringValue(val);
+    }
+    return builder.build();
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/SimpleMockServerTest.java
+++ b/src/test/java/liquibase/ext/spanner/SimpleMockServerTest.java
@@ -1,0 +1,42 @@
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import liquibase.Liquibase;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class SimpleMockServerTest extends AbstractMockServerTest {
+  
+  @Test
+  void testCreateTableStatement() throws SQLException {
+    String statement = "CREATE TABLE FOO (ID INT64) PRIMARY KEY (ID)";
+    addUpdateDdlStatementsResponse(statement);
+    
+    try (Connection con = createConnection()) {
+      con.createStatement().execute("CREATE TABLE FOO (ID INT64) PRIMARY KEY (ID)");
+    }
+    assertThat(mockAdmin.getRequests()).hasSize(1);
+    assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+    assertThat(getUpdateDdlStatementsList(0)).containsExactly(statement).inOrder();
+  }
+  
+  @Test
+  void testInitLiquibase() throws Exception {
+    mockSpanner.putStatementResult(StatementResult.query(SELECT_COUNT_FROM_DATABASECHANGELOG, createCountResultSet(0L)));
+    mockSpanner.putStatementResult(StatementResult.query(
+        SELECT_FROM_DATABASECHANGELOG,
+        DatabaseChangeLog.createChangeSetResultSet(ImmutableList.of())
+      ));
+    try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, "changelog.spanner.sql")) {
+      liquibase.validate();
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a simple mock server for quick testing without the need to start the emulator or a real Spanner instance.

Depends on #5, so this should only be merged after that.