### PR TITLE
feat: add support for createIndex change type

### DIFF
--- a/src/test/java/liquibase/ext/spanner/CreateIndexTest.java
+++ b/src/test/java/liquibase/ext/spanner/CreateIndexTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class CreateIndexTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testCreateSingersLastNameIndexFromYaml() throws Exception {
+    String expectedSql = "CREATE INDEX Idx_Singers_LastName ON Singers(LastName)";
+    addUpdateDdlStatementsResponse(expectedSql);
+
+    for (String file : new String[] {"create-index-singers-last-name.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    assertThat(mockAdmin.getRequests()).hasSize(1);
+    assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+    UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(0);
+    assertThat(request.getStatementsList()).hasSize(1);
+    assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void testCreateSingersFirstNameIndexFromYaml() throws Exception {
+    String expectedSql = "CREATE INDEX Idx_Singers_FirstName ON Singers(FirstName DESC)";
+    addUpdateDdlStatementsResponse(expectedSql);
+
+    for (String file : new String[] {"create-index-singers-first-name.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    assertThat(mockAdmin.getRequests()).hasSize(1);
+    assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+    UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(0);
+    assertThat(request.getStatementsList()).hasSize(1);
+    assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql);
+  }
+
+  @Test
+  void testCreateSingersFirstAndLastNameIndexFromYaml() throws Exception {
+    String expectedSql =
+        "CREATE UNIQUE INDEX Idx_Singers_FirstAndLastName ON Singers(FirstName DESC, LastName)";
+    addUpdateDdlStatementsResponse(expectedSql);
+
+    for (String file : new String[] {"create-index-singers-first-and-last-name.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    assertThat(mockAdmin.getRequests()).hasSize(1);
+    assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+    UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(0);
+    assertThat(request.getStatementsList()).hasSize(1);
+    assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql);
+  }
+}

--- a/src/test/resources/create-index-singers-first-and-last-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-first-and-last-name.spanner.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1-create-index
+     author: spanner-liquibase-tests
+     changes:
+       - createIndex:
+          tableName: Singers
+          indexName: Idx_Singers_FirstAndLastName
+          unique:    true
+          columns:
+            - column:
+                name:       FirstName
+                descending: true
+            - column:
+                name:       LastName

--- a/src/test/resources/create-index-singers-first-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-first-name.spanner.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1-create-index
+     author: spanner-liquibase-tests
+     changes:
+       - createIndex:
+          tableName: Singers
+          indexName: Idx_Singers_FirstName
+          unique:    false
+          columns:
+            - column:
+                name:       FirstName
+                descending: true

--- a/src/test/resources/create-index-singers-last-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-last-name.spanner.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1-create-index
+     author: spanner-liquibase-tests
+     changes:
+       - createIndex:
+          tableName: Singers
+          indexName: Idx_Singers_LastName
+          unique:    false
+          columns:
+            - column:
+                name:       LastName
+                descending: false


### PR DESCRIPTION
The standard generator for `createIndex` already works for Cloud Spanner, so this change actually only adds tests for that change type.

This PR depends on #9 which should be merged first.