### PR TITLE
test: add tests for DropTable

### DIFF
--- a/src/test/java/liquibase/ext/spanner/DropTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/DropTableTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package liquibase.ext.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -21,7 +34,7 @@ public class DropTableTest extends AbstractMockServerTest {
   }
 
   @Test
-  void testCreateSingersTableFromYaml() throws Exception {
+  void testDropSingersTableFromYaml() throws Exception {
     String expectedSql = "DROP TABLE Singers";
     addUpdateDdlStatementsResponse(expectedSql);
 

--- a/src/test/java/liquibase/ext/spanner/DropTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/DropTableTest.java
@@ -1,0 +1,41 @@
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class DropTableTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testCreateSingersTableFromYaml() throws Exception {
+    String expectedSql = "DROP TABLE Singers";
+    addUpdateDdlStatementsResponse(expectedSql);
+
+    for (String file : new String[] {"drop-singers-table.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    assertThat(mockAdmin.getRequests()).hasSize(1);
+    assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+    UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(0);
+    assertThat(request.getStatementsList()).hasSize(1);
+    assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql);
+  }
+}

--- a/src/test/resources/drop-singers-table.spanner.yaml
+++ b/src/test/resources/drop-singers-table.spanner.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - dropTable:
+          tableName: Singers


### PR DESCRIPTION
The standard generator for dropTable already works for Cloud Spanner, so this change only adds a test for that change type.

This PR depends on #9 which should be merged first.