### PR TITLE
feat: add validation errors for add/drop primary key

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerAddPrimaryKeyGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerAddPrimaryKeyGenerator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddPrimaryKeyGenerator;
+import liquibase.statement.core.AddPrimaryKeyStatement;
+
+public class SpannerAddPrimaryKeyGenerator extends AddPrimaryKeyGenerator {
+  static final String ADD_PK_VALIDATION_ERROR =
+      "Cloud Spanner does not support adding a primary key to an existing table";
+
+  @Override
+  public ValidationErrors validate(
+      AddPrimaryKeyStatement addPrimaryKeyStatement,
+      Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(addPrimaryKeyStatement, database, sqlGeneratorChain);
+    errors.addError(ADD_PK_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(AddPrimaryKeyStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/SpannerDropPrimaryKeyGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerDropPrimaryKeyGenerator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.DropPrimaryKeyGenerator;
+import liquibase.statement.core.DropPrimaryKeyStatement;
+
+public class SpannerDropPrimaryKeyGenerator extends DropPrimaryKeyGenerator {
+  static final String DROP_PK_VALIDATION_ERROR =
+      "Cloud Spanner does not support dropping a primary key from a table";
+
+  @Override
+  public ValidationErrors validate(
+      DropPrimaryKeyStatement dropPrimaryKeyStatement,
+      Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(dropPrimaryKeyStatement, database, sqlGeneratorChain);
+    errors.addError(DROP_PK_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(DropPrimaryKeyStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/AddDropPrimaryKeyTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddDropPrimaryKeyTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package liquibase.ext.spanner;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/test/java/liquibase/ext/spanner/AddDropPrimaryKeyTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddDropPrimaryKeyTest.java
@@ -1,0 +1,52 @@
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.ValidationFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class AddDropPrimaryKeyTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAddPrimaryKeySingersFromYaml() throws Exception {
+    for (String file : new String[] {"add-primary-key-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage()).contains(SpannerAddPrimaryKeyGenerator.ADD_PK_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+
+  @Test
+  void testDropPrimaryKeySingersFromYaml() throws Exception {
+    for (String file : new String[] {"drop-primary-key-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerDropPrimaryKeyGenerator.DROP_PK_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/resources/add-primary-key-singers.spanner.yaml
+++ b/src/test/resources/add-primary-key-singers.spanner.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - addPrimaryKey:
+          constraintName: PK_Singers
+          tableName:  Singers
+          columnNames: SingerId

--- a/src/test/resources/drop-primary-key-singers.spanner.yaml
+++ b/src/test/resources/drop-primary-key-singers.spanner.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - dropPrimaryKey:
+          tableName:  Singers


### PR DESCRIPTION
Adding/dropping primary keys is not supported in Cloud Spanner.