### PR TITLE
feat: add validation errors for add/drop unique constraint

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerAddUniqueConstraintGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerAddUniqueConstraintGenerator.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddUniqueConstraintGenerator;
+import liquibase.statement.core.AddUniqueConstraintStatement;
+
+/**
+ * Cloud Spanner does not support unique constraints. Applications should create a unique index
+ * instead.
+ */
+public class SpannerAddUniqueConstraintGenerator extends AddUniqueConstraintGenerator {
+  static final String ADD_UNIQUE_CONSTRAINT_VALIDATION_ERROR =
+      "Cloud Spanner does not support unique constraints. Use a unique index instead.";
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(AddUniqueConstraintStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+
+  @Override
+  public ValidationErrors validate(
+      AddUniqueConstraintStatement addUniqueConstraintStatement,
+      Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors =
+        super.validate(addUniqueConstraintStatement, database, sqlGeneratorChain);
+    errors.addError(ADD_UNIQUE_CONSTRAINT_VALIDATION_ERROR);
+    return errors;
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/SpannerDropUniqueConstraintGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerDropUniqueConstraintGenerator.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.DropUniqueConstraintGenerator;
+import liquibase.statement.core.DropUniqueConstraintStatement;
+
+/**
+ * Cloud Spanner does not support unique constraints. Applications should create a unique index
+ * instead.
+ */
+public class SpannerDropUniqueConstraintGenerator extends DropUniqueConstraintGenerator {
+  static final String DROP_UNIQUE_CONSTRAINT_VALIDATION_ERROR =
+      "Cloud Spanner does not support unique constraints. Use a unique index instead.";
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(DropUniqueConstraintStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+
+  @Override
+  public ValidationErrors validate(
+      DropUniqueConstraintStatement addUniqueConstraintStatement,
+      Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors =
+        super.validate(addUniqueConstraintStatement, database, sqlGeneratorChain);
+    errors.addError(DROP_UNIQUE_CONSTRAINT_VALIDATION_ERROR);
+    return errors;
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/AddDropUniqueConstraintTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddDropUniqueConstraintTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.ValidationFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class AddDropUniqueConstraintTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAddUniqueConstraintSingersFromYaml() throws Exception {
+    for (String file : new String[] {"add-unique-constraint-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerAddUniqueConstraintGenerator.ADD_UNIQUE_CONSTRAINT_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+
+  @Test
+  void testDropUniqueConstraintSingersFromYaml() throws Exception {
+    for (String file : new String[] {"drop-unique-constraint-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerDropUniqueConstraintGenerator.DROP_UNIQUE_CONSTRAINT_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/resources/add-unique-constraint-singers.spanner.yaml
+++ b/src/test/resources/add-unique-constraint-singers.spanner.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - addUniqueConstraint:
+          constraintName: UC_Singers
+          tableName:  Singers
+          columnNames: FirstName, LastName

--- a/src/test/resources/drop-unique-constraint-singers.spanner.yaml
+++ b/src/test/resources/drop-unique-constraint-singers.spanner.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - dropUniqueConstraint:
+          constraintName: UC_Singers
+          tableName:  Singers


### PR DESCRIPTION
Cloud Spanner does not support unique constraints and unique indexes should be used instead. Those can also be created using Liquibase, so we should not automatically convert unique constraints to unique indices in a generator.