### PR TITLE
feat: add validation error for rename column

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerRenameColumnGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerRenameColumnGenerator.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package liquibase.ext.spanner;
 
 import liquibase.database.Database;

--- a/src/main/java/liquibase/ext/spanner/SpannerRenameColumnGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerRenameColumnGenerator.java
@@ -1,0 +1,31 @@
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.RenameColumnGenerator;
+import liquibase.statement.core.RenameColumnStatement;
+
+public class SpannerRenameColumnGenerator extends RenameColumnGenerator {
+  static final String RENAME_COLUMN_VALIDATION_ERROR =
+      "Cloud Spanner does not support renaming a column";
+
+  @Override
+  public ValidationErrors validate(
+      RenameColumnStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(statement, database, sqlGeneratorChain);
+    errors.addError(RENAME_COLUMN_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(RenameColumnStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/RenameColumnTest.java
+++ b/src/test/java/liquibase/ext/spanner/RenameColumnTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.ValidationFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class RenameColumnTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAddPrimaryKeySingersFromYaml() throws Exception {
+    for (String file : new String[] {"rename-column-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerRenameColumnGenerator.RENAME_COLUMN_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/resources/rename-column-singers.spanner.yaml
+++ b/src/test/resources/rename-column-singers.spanner.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - renameColumn:
+          tableName:  Singers
+          oldColumnName: FirstName
+          newColumnName: GivenName


### PR DESCRIPTION
Cloud Spanner does not support renaming an existing column. This adds a validation error for those change types for Cloud Spanner databases.