### PR TITLE
feat: add validation errors for default values

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerAddDefaultValueGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerAddDefaultValueGenerator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddDefaultValueGenerator;
+import liquibase.statement.core.AddDefaultValueStatement;
+
+public class SpannerAddDefaultValueGenerator extends AddDefaultValueGenerator {
+  static final String ADD_DEFAULT_VALUE_VALIDATION_ERROR =
+      "Cloud Spanner does not support adding a default value to a column";
+
+  @Override
+  public ValidationErrors validate(
+      AddDefaultValueStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(statement, database, sqlGeneratorChain);
+    errors.addError(ADD_DEFAULT_VALUE_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(AddDefaultValueStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/SpannerDropDefaultValueGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerDropDefaultValueGenerator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.DropDefaultValueGenerator;
+import liquibase.statement.core.DropDefaultValueStatement;
+
+public class SpannerDropDefaultValueGenerator extends DropDefaultValueGenerator {
+  static final String DROP_DEFAULT_VALUE_VALIDATION_ERROR =
+      "Cloud Spanner does not support dropping a default value from a column";
+
+  @Override
+  public ValidationErrors validate(
+      DropDefaultValueStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(statement, database, sqlGeneratorChain);
+    errors.addError(DROP_DEFAULT_VALUE_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(DropDefaultValueStatement statement, Database database) {
+    return (database instanceof CloudSpanner);
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/AddDropDefaultValueTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddDropDefaultValueTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.ValidationFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class AddDropDefaultValueTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAddDefaultValueSingersFromYaml() throws Exception {
+    for (String file : new String[] {"add-default-value-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerAddDefaultValueGenerator.ADD_DEFAULT_VALUE_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+
+  @Test
+  void testDropDefaultValueSingersFromYaml() throws Exception {
+    for (String file : new String[] {"drop-default-value-singers.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains(SpannerDropDefaultValueGenerator.DROP_DEFAULT_VALUE_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/resources/add-default-value-singers.spanner.yaml
+++ b/src/test/resources/add-default-value-singers.spanner.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - addDefaultValue:
+          tableName:  Singers
+          columnName: LastName
+          defaultValue: "some-name"

--- a/src/test/resources/drop-default-value-singers.spanner.yaml
+++ b/src/test/resources/drop-default-value-singers.spanner.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - dropDefaultValue:
+          tableName:  Singers
+          columnName: LastName


### PR DESCRIPTION
Cloud Spanner does currently not support setting a default value for a column.