### PR TITLE
feat: add generator for lookup table

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerAddLookupTableChange.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerAddLookupTableChange.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package liquibase.ext.spanner;
 
 import java.util.ArrayList;

--- a/src/main/java/liquibase/ext/spanner/SpannerAddLookupTableChange.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerAddLookupTableChange.java
@@ -1,0 +1,80 @@
+package liquibase.ext.spanner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.change.core.AddForeignKeyConstraintChange;
+import liquibase.change.core.AddLookupTableChange;
+import liquibase.database.Database;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
+import liquibase.structure.core.Column;
+
+@DatabaseChange(
+    name = "addLookupTable",
+    description =
+        "Creates a lookup table containing values stored in a column and creates a foreign key to the new table.",
+    priority = ChangeMetaData.PRIORITY_DATABASE,
+    appliesTo = "column")
+public class SpannerAddLookupTableChange extends AddLookupTableChange {
+
+  @Override
+  public boolean supports(Database database) {
+    return (database instanceof CloudSpanner);
+  }
+
+  public SqlStatement[] generateStatements(Database database) {
+    List<SqlStatement> statements = new ArrayList<>();
+
+    String newTableCatalogName = getNewTableCatalogName();
+    String newTableSchemaName = getNewTableSchemaName();
+
+    String existingTableCatalogName = getExistingTableCatalogName();
+    String existingTableSchemaName = getExistingTableSchemaName();
+
+    SqlStatement[] createTablesSQL =
+        new SqlStatement[] {
+          new RawSqlStatement(
+              "CREATE TABLE "
+                  + database.escapeTableName(
+                      newTableCatalogName, newTableSchemaName, getNewTableName())
+                  + " ("
+                  + database.escapeObjectName(getNewColumnName(), Column.class)
+                  + " "
+                  + getNewColumnDataType()
+                  + " NOT NULL) PRIMARY KEY ("
+                  + database.escapeObjectName(getNewColumnName(), Column.class)
+                  + ")"),
+          new RawSqlStatement(
+              "INSERT INTO "
+                  + database.escapeTableName(
+                      newTableCatalogName, newTableSchemaName, getNewTableName())
+                  + " ("
+                  + database.escapeObjectName(getNewColumnName(), Column.class)
+                  + ") SELECT DISTINCT "
+                  + database.escapeObjectName(getExistingColumnName(), Column.class)
+                  + " FROM "
+                  + database.escapeTableName(
+                      existingTableCatalogName, existingTableSchemaName, getExistingTableName())
+                  + " WHERE "
+                  + database.escapeObjectName(getExistingColumnName(), Column.class)
+                  + " IS NOT NULL"),
+        };
+    statements.addAll(Arrays.asList(createTablesSQL));
+
+    AddForeignKeyConstraintChange addFKChange = new AddForeignKeyConstraintChange();
+    addFKChange.setBaseTableSchemaName(existingTableSchemaName);
+    addFKChange.setBaseTableName(getExistingTableName());
+    addFKChange.setBaseColumnNames(getExistingColumnName());
+    addFKChange.setReferencedTableSchemaName(newTableSchemaName);
+    addFKChange.setReferencedTableName(getNewTableName());
+    addFKChange.setReferencedColumnNames(getNewColumnName());
+
+    addFKChange.setConstraintName(getFinalConstraintName());
+    statements.addAll(Arrays.asList(addFKChange.generateStatements(database)));
+
+    return statements.toArray(new SqlStatement[statements.size()]);
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/AddLookupTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddLookupTableTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TempMockSpannerServiceImpl.StatementResult;
+import com.google.common.base.Predicate;
+import com.google.protobuf.AbstractMessage;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class AddLookupTableTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAddLookupTableSingersCountriesFromYaml() throws Exception {
+    String[] expectedSql =
+        new String[] {
+          "CREATE TABLE Countries (Name STRING(100) NOT NULL) PRIMARY KEY (Name)",
+          "ALTER TABLE Singers ADD CONSTRAINT FK_Singers_Countries FOREIGN KEY (Country) REFERENCES Countries (Name)",
+        };
+    for (String sql : expectedSql) {
+      addUpdateDdlStatementsResponse(sql);
+    }
+    final String insert =
+        "INSERT INTO Countries (Name) SELECT DISTINCT Country FROM Singers WHERE Country IS NOT NULL";
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of(insert), 100L));
+
+    for (String file : new String[] {"add-lookup-table-singers-countries.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    mockSpanner.waitForRequestsToContain(
+        new Predicate<AbstractMessage>() {
+          @Override
+          public boolean apply(AbstractMessage input) {
+            if (input instanceof ExecuteSqlRequest) {
+              ExecuteSqlRequest request = (ExecuteSqlRequest) input;
+              return request.getSql().equals(insert);
+            }
+            return false;
+          }
+        },
+        500L);
+    assertThat(mockAdmin.getRequests()).hasSize(expectedSql.length);
+    for (int i = 0; i < expectedSql.length; i++) {
+      assertThat(mockAdmin.getRequests().get(i)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+      UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(i);
+      assertThat(request.getStatementsList()).hasSize(1);
+      assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql[i]);
+    }
+  }
+}

--- a/src/test/resources/add-lookup-table-singers-countries.spanner.yaml
+++ b/src/test/resources/add-lookup-table-singers-countries.spanner.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       # Creates a lookup table for the home country of a Singer. This will change the
+       # country column from a pure text column to one tha tis required to reference a
+       # value in another table (i.e. the 'lookup table').
+       - addLookupTable:
+          existingTableName: Singers
+          existingColumnName: Country
+          newTableName: Countries
+          newColumnName: Name
+          newColumnDataType: STRING(100)
+          constraintName: FK_Singers_Countries


### PR DESCRIPTION
Adds a generator for the `addLookupTable` change type. Cloud Spanner does not have any `CREATE TABLE AS SELECT ...` type statement, so it needs a custom generator.