### PR TITLE
Adding more tests with emulator and real spanner with one bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.testcontainers:testcontainers:1.13.0")
+    testImplementation("org.testcontainers:testcontainers:1.15.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("com.google.truth:truth:1.0.1")
     testImplementation("org.mockito:mockito-core:1.10.19")

--- a/src/main/java/liquibase/ext/spanner/DecimalSpannerType.java
+++ b/src/main/java/liquibase/ext/spanner/DecimalSpannerType.java
@@ -6,7 +6,7 @@ import liquibase.datatype.core.DecimalType;
 
 /** DECIMAL is translated to NUMERIC. */
 public class DecimalSpannerType extends DecimalType {
-  private static final DatabaseDataType DECIMAL = new DatabaseDataType("DECIMAL");
+  private static final DatabaseDataType DECIMAL = new DatabaseDataType("NUMERIC");
 
   @Override
   public boolean supports(Database database) {

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -163,25 +163,26 @@ public class LiquibaseTests {
   void doLiquibaseCreateAndRollbackTest(String changeLogFile, TestHarness.Connection testHarness)
       throws SQLException, LiquibaseException {
 
-    List<Map<String, Object>> rows =
-        tableColumns(testHarness.getJDBCConnection(), "rollback_table");
-    Assert.assertTrue(rows.size() == 0);
+    testTableColumns(testHarness.getJDBCConnection(), "rollback_table");
+
 
     Liquibase liquibase = getLiquibase(testHarness, changeLogFile);
     liquibase.update(null, new LabelExpression("rollback_stuff"));
     liquibase.tag("tag-at-rollback");
 
-    rows = tableColumns(testHarness.getJDBCConnection(), "rollback_table");
-    Assert.assertTrue(rows.size() == 2);
-    Assert.assertTrue(rows.get(0).get("COLUMN_NAME").equals("id"));
-    Assert.assertTrue(rows.get(1).get("COLUMN_NAME").equals("name"));
+    testTableColumns(testHarness.getJDBCConnection(), "rollback_table",
+        new ColDesc("id", "INT64", Boolean.FALSE),
+        new ColDesc("name", "STRING(255)")
+    );
+
+    testTablePrimaryKeys(testHarness.getJDBCConnection(), "rollback_table",
+        new ColDesc("id"));
 
     // Do rollback
     liquibase.rollback(1, null);
 
     // Ensure nothing is there!
-    rows = tableColumns(testHarness.getJDBCConnection(), "rollback_table");
-    Assert.assertTrue(rows.size() == 0);
+    testTableColumns(testHarness.getJDBCConnection(), "rollback_table");
   }
 
   @Test
@@ -203,7 +204,7 @@ public class LiquibaseTests {
 
     // Expect all of the columns and types
     testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes",
-        new ColDesc("ColBigInt", "INT64"),
+        new ColDesc("ColBigInt", "INT64", Boolean.FALSE),
         new ColDesc("ColBlob", "BYTES(MAX)"),
         new ColDesc("ColBoolean", "BOOL"),
         new ColDesc("ColChar", "STRING(100)"),
@@ -224,6 +225,9 @@ public class LiquibaseTests {
         new ColDesc("ColUUID", "STRING(36)"),
         new ColDesc("ColXml", "STRING(MAX)")
         );
+
+    testTablePrimaryKeys(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes",
+        new ColDesc("ColBigInt"));
 
     // Do rollback
     liquibase.rollback(1, null);
@@ -251,7 +255,7 @@ public class LiquibaseTests {
 
     // Expect all of the columns and types
     testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes",
-        new ColDesc("ColBigInt", "INT64"),
+        new ColDesc("ColBigInt", "INT64", Boolean.FALSE),
         new ColDesc("ColBlob", "BYTES(MAX)"),
         new ColDesc("ColBoolean", "BOOL"),
         new ColDesc("ColChar", "STRING(100)"),
@@ -275,6 +279,9 @@ public class LiquibaseTests {
         new ColDesc("ColXml", "STRING(MAX)")
     );
 
+    testTablePrimaryKeys(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes",
+        new ColDesc("ColBigInt"));
+
     // Do rollback
     liquibase.rollback(1, null);
 
@@ -285,32 +292,65 @@ public class LiquibaseTests {
   public static class ColDesc {
     public final String name;
     public final String type;
+    public final Boolean isNullable;
+    public ColDesc(String name) {
+      this(name, null, Boolean.TRUE);
+    }
     public ColDesc(String name, String type) {
+      this(name, type, Boolean.TRUE);
+    }
+    public ColDesc(String name, String type, Boolean isNullable) {
       this.name = name;
       this.type = type;
+      this.isNullable = isNullable;
     }
   }
 
   static void testTableColumns(java.sql.Connection conn, String table, ColDesc... cols)
       throws SQLException {
-    List<Map<String, Object>> rows = tableColumns(conn, table);
-    for (int i = 0; i < cols.length; i++) {
-      Assert.assertEquals(
-          rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name),
-          0);
-      Assert.assertEquals(
-          rows.get(i).get("TYPE_NAME").toString().compareToIgnoreCase(cols[i].type),
-          0);
-    }
-  }
 
-  static List<Map<String, Object>> tableColumns(java.sql.Connection conn, String table)
-      throws SQLException {
     boolean readOnlyStatus = conn.isReadOnly();
     conn.setReadOnly(true);
     ResultSet rs = conn.getMetaData().getColumns(null, null, table, null);
     conn.setReadOnly(readOnlyStatus);
-    return getResults(rs);
+
+    List<Map<String, Object>> rows = getResults(rs);
+
+    Assert.assertEquals(rows.size(), cols.length);
+    for (int i = 0; i < cols.length; i++) {
+      Assert.assertEquals(
+          rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name),
+          0);
+      if (cols[i].type != null) {
+        Assert.assertEquals(
+            rows.get(i).get("TYPE_NAME").toString().compareToIgnoreCase(cols[i].type),
+            0);
+      }
+      if (cols[i].isNullable != null) {
+        String expectedValue = cols[i].isNullable ? "YES" : "NO";
+        Assert.assertEquals(
+            rows.get(i).get("IS_NULLABLE").toString().compareToIgnoreCase(expectedValue),
+            0);
+      }
+    }
+  }
+
+  static void testTablePrimaryKeys(java.sql.Connection conn, String table, ColDesc... cols)
+      throws SQLException {
+
+    boolean readOnlyStatus = conn.isReadOnly();
+    conn.setReadOnly(true);
+    ResultSet rs = conn.getMetaData().getPrimaryKeys(null, null, table);
+    conn.setReadOnly(readOnlyStatus);
+
+    List<Map<String, Object>> rows = getResults(rs);
+
+    Assert.assertEquals(rows.size(), cols.length);
+    for (int i = 0; i < cols.length; i++) {
+      Assert.assertEquals(
+          rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name),
+          0);
+    }
   }
 
   static List<Map<String, Object>> testQuery(java.sql.Connection conn, String query)

--- a/src/test/java/liquibase/ext/spanner/CreateTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/CreateTableTest.java
@@ -77,7 +77,7 @@ public class CreateTableTest extends AbstractMockServerTest {
   @Test
   void testCreateTableWithAllLiquibaseTypesFromYaml() throws Exception {
     String expectedSql =
-        "CREATE TABLE TableWithAllLiquibaseTypes (ColBigInt INT64 NOT NULL, ColBlob BYTES(MAX), ColBoolean BOOL, ColChar STRING(100), ColNChar STRING(50), ColNVarchar STRING(100), ColVarchar STRING(200), ColClob STRING(MAX), ColDateTime TIMESTAMP, ColTimestamp timestamp, ColDate date, ColDecimal DECIMAL, ColDouble FLOAT64, ColFloat FLOAT64, ColInt INT64, ColMediumInt INT64, ColNumber NUMERIC, ColSmallInt INT64, ColTime TIMESTAMP, ColTinyInt INT64, ColUUID STRING(36), ColXml STRING(MAX)) PRIMARY KEY (ColBigInt)";
+        "CREATE TABLE TableWithAllLiquibaseTypes (ColBigInt INT64 NOT NULL, ColBlob BYTES(MAX), ColBoolean BOOL, ColChar STRING(100), ColNChar STRING(50), ColNVarchar STRING(100), ColVarchar STRING(200), ColClob STRING(MAX), ColDateTime TIMESTAMP, ColTimestamp timestamp, ColDate date, ColDecimal NUMERIC, ColDouble FLOAT64, ColFloat FLOAT64, ColInt INT64, ColMediumInt INT64, ColNumber NUMERIC, ColSmallInt INT64, ColTime TIMESTAMP, ColTinyInt INT64, ColUUID STRING(36), ColXml STRING(MAX)) PRIMARY KEY (ColBigInt)";
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"create-table-with-all-liquibase-types.spanner.yaml"}) {

--- a/src/test/resources/create-table-with-all-liquibase-types-except-decimal.spanner.yaml
+++ b/src/test/resources/create-table-with-all-liquibase-types-except-decimal.spanner.yaml
@@ -1,0 +1,90 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.3
+     labels: version 0.3
+     author: spanner-liquibase-tests
+     changes:
+       - createTable:
+          remarks:   Table with all possible Liquibase data types. Money type is not supported.
+          tableName: TableWithAllLiquibaseTypes
+          columns:
+            -  column:
+                name:    ColBigInt
+                type:    BIGINT
+                constraints:
+                  primaryKey: true
+            -  column:
+                name:    ColBlob
+                type:    BLOB
+            -  column:
+                name:    ColBoolean
+                type:    BOOLEAN
+            -  column:
+                name:    ColChar
+                type:    CHAR(100)
+            -  column:
+                name:    ColNChar
+                type:    NCHAR(50)
+            -  column:
+                name:    ColNVarchar
+                type:    NVARCHAR(100)
+            -  column:
+                name:    ColVarchar
+                type:    VARCHAR(200)
+            -  column:
+                name:    ColClob
+                type:    CLOB
+            -  column:
+                name:    ColDateTime
+                type:    DATETIME
+            -  column:
+                name:    ColTimestamp
+                type:    TIMESTAMP
+            -  column:
+                name:    ColDate
+                type:    DATE
+            -  column:
+                name:    ColDouble
+                type:    DOUBLE
+            -  column:
+                name:    ColFloat
+                type:    FLOAT
+            -  column:
+                name:    ColInt
+                type:    INT
+            -  column:
+                name:    ColMediumInt
+                type:    MEDIUMINT
+            -  column:
+                name:    ColSmallInt
+                type:    SMALLINT
+            -  column:
+                name:    ColTime
+                type:    TIME
+            -  column:
+                name:    ColTinyInt
+                type:    TINYINT
+            -  column:
+                name:    ColUUID
+                type:    UUID
+            -  column:
+                name:    ColXml
+                type:    XML

--- a/src/test/resources/create_table.spanner.sql
+++ b/src/test/resources/create_table.spanner.sql
@@ -23,8 +23,8 @@
 START BATCH DDL;
 create table rollback_table
 (
-    id   int64,
-    name string(MAX),
+    id   int64 NOT NULL,
+    name string(255),
 ) PRIMARY KEY (id);
 RUN BATCH;
 --rollback DROP TABLE rollback_table;


### PR DESCRIPTION
Changes -
- Decimal type was incorrectly DECIMAL Spanner type rather than NUMERIC
- Added create-all-types for emulator and real Spanner. Emulator does not support NUMERIC yet so needed a different version.
- Tested for NOT NULL, types, and PRIMARY keys.
- Adjusted existing types to test for column type, NOT NULL, and PRIMARY keys as well.
- Re-factored some testing code