### PR TITLE
Circleci fix for marking releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
           path: build/test-results/test
       - store_artifacts:
           path: build/libs
+      - persist_to_workspace
+          root: build/libs
+          paths:
+            - *.jar
 
   # Publish on a tag
   publish_github_release:
@@ -38,11 +42,17 @@ jobs:
       - image: cibuilds/github:0.10
     steps:
       - attach_workspace:
-          at: ./build/libs
+          at: ./workspace
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./
+            ghr -n "Release v${CIRCLE_TAG}"  \
+                -t ${GITHUB_TOKEN} \
+                -u ${CIRCLE_PROJECT_USERNAME} \
+                -r ${CIRCLE_PROJECT_REPONAME} \
+                -c ${CIRCLE_SHA1} \
+                -delete ${CIRCLE_TAG} \
+                ./workspace
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - persist_to_workspace:
           root: build/libs
           paths:
-            - *.jar
+            - "*.jar"
 
   # Publish on a tag
   publish_github_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   # Publish on a tag
   publish_github_release:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
           at: ./workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           path: build/test-results/test
       - store_artifacts:
           path: build/libs
-      - persist_to_workspace
+      - persist_to_workspace:
           root: build/libs
           paths:
             - *.jar


### PR DESCRIPTION
Creating a new release (see the release created -- done through CircleCI, although I marked it as prerelease) fixes.

To create a new release:
- switch to master branch at HEAD
- apply a git tag of form N.N.N
- push tags
