### PR TITLE
Liquibase 4 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+// Liquibase <4 uses Liquibase-Package to determine what to scan
+jar {
+  manifest {
+    attributes(
+      "Liquibase-Package": "liquibase.ext.spanner"
+    )
+  }
+}
+
+// Liquibase 4 uses ServiceLoader
 serviceLoader {
     serviceInterface 'liquibase.database.Database'
     serviceInterface 'liquibase.datatype.LiquibaseDataType'
@@ -62,6 +72,7 @@ dependencies {
     // Liquibase Core - needed for testing and docker container
     implementation("org.liquibase:liquibase-core:4.2.0")
     implementation("org.yaml:snakeyaml:1.26")
+    implementation("org.apache.commons:commons-lang3:3.11")
     
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id "java"
     id "com.google.cloud.tools.jib" version "2.4.0"
     id "com.github.johnrengelman.shadow" version "6.0.0"
+    id "com.github.harbby.gradle.serviceloader" version "1.1.2"
 }
 
 
@@ -42,6 +43,13 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+serviceLoader {
+    serviceInterface 'liquibase.database.Database'
+    serviceInterface 'liquibase.datatype.LiquibaseDataType'
+    serviceInterface 'liquibase.sqlgenerator.SqlGenerator'
+    serviceInterface 'liquibase.change.Change'
+    serviceInterface 'liquibase.changelog.ChangeLogHistoryService'
+}
 
 dependencies {
 
@@ -52,7 +60,7 @@ dependencies {
     implementation("com.google.cloud:google-cloud-logging-logback")
 
     // Liquibase Core - needed for testing and docker container
-    implementation("org.liquibase:liquibase-core:3.8.9")
+    implementation("org.liquibase:liquibase-core:4.2.0")
     implementation("org.yaml:snakeyaml:1.26")
     
     // Testing
@@ -74,8 +82,12 @@ dependencies {
 }
 
 
-// Run unit tests (Spanner emulator)
+// Run unit tests (Spanner emulator and mock tests)
 test {
+
+  // serviceLoaderBuild is necessary for Liquibase to find the extensions
+  dependsOn "serviceLoaderBuild"
+
   useJUnitPlatform {
     excludeTags "integration"
   }
@@ -88,10 +100,14 @@ test {
 // Also requires GOOGLE_APPLICATION_CREDENTIALS environment variable
 // if using a JSON key for authentication.
 task integrationTest(type: Test) {
-    useJUnitPlatform {
-        includeTags "integration"
-    }
-    shouldRunAfter test
+  shouldRunAfter "test"
+
+  // serviceLoaderBuild is necessary for Liquibase to find the extensions
+  dependsOn "serviceLoaderBuild"
+
+  useJUnitPlatform {
+    includeTags "integration"
+  }
 }
 
 // Output shadowJar that can be used directly by Liquibase

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -15,29 +15,10 @@ package liquibase.ext.spanner;
 
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
-import liquibase.servicelocator.ServiceLocator;
-import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGenerator;
-import liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator;
-import liquibase.sqlgenerator.core.UnlockDatabaseChangeLogGenerator;
 
 public class CloudSpanner extends AbstractJdbcDatabase {
 
-  // Service Locator is used by Liquibase to find available extension classes.
-  // This is needed to register this package to be searched.
-  static {
-
-    // Add classpath for extensions
-    ServiceLocator.getInstance().addPackageToScan("liquibase.ext.spanner");
-  }
-
   public CloudSpanner() {
-    SqlGeneratorFactory sqlGeneratorFactory = SqlGeneratorFactory.getInstance();
-    sqlGeneratorFactory.register(new CreateDatabaseChangeLogTableGenerator());
-    sqlGeneratorFactory.register(new SpannerInitializeChangeLogLockTableGenerator());
-    sqlGeneratorFactory.register(new SpannerCreateDatabaseChangeLogTableGenerator());
-    sqlGeneratorFactory.register(new UnlockDatabaseChangeLogGenerator());
-    sqlGeneratorFactory.register(new LockDatabaseChangeLogGenerator());
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
@@ -37,6 +37,7 @@ public class SpannerCreateTableGenerator extends CreateTableGenerator {
     // of the primary key constraint to be empty, but that cannot be defined in the metamodel of
     // Liquibase.
     errors.checkRequiredField("primary key", createTableStatement.getPrimaryKeyConstraint());
+
     return errors;
   }
 

--- a/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
@@ -48,7 +48,7 @@ public class SpannerCreateTableGenerator extends CreateTableGenerator {
     StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
     buffer.append(
         database.escapeColumnNameList(
-            StringUtil.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+            StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
     buffer.append(")");
 
     String pk = buffer.toString();

--- a/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
@@ -21,7 +21,7 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateTableGenerator;
 import liquibase.statement.core.CreateTableStatement;
 import liquibase.structure.DatabaseObject;
-import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 public class SpannerCreateTableGenerator extends CreateTableGenerator {
 
@@ -37,7 +37,6 @@ public class SpannerCreateTableGenerator extends CreateTableGenerator {
     // of the primary key constraint to be empty, but that cannot be defined in the metamodel of
     // Liquibase.
     errors.checkRequiredField("primary key", createTableStatement.getPrimaryKeyConstraint());
-
     return errors;
   }
 
@@ -49,7 +48,7 @@ public class SpannerCreateTableGenerator extends CreateTableGenerator {
     StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
     buffer.append(
         database.escapeColumnNameList(
-            StringUtil.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+            StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
     buffer.append(")");
 
     String pk = buffer.toString();

--- a/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerCreateTableGenerator.java
@@ -21,7 +21,7 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateTableGenerator;
 import liquibase.statement.core.CreateTableStatement;
 import liquibase.structure.DatabaseObject;
-import liquibase.util.StringUtils;
+import liquibase.util.StringUtil;
 
 public class SpannerCreateTableGenerator extends CreateTableGenerator {
 
@@ -49,7 +49,7 @@ public class SpannerCreateTableGenerator extends CreateTableGenerator {
     StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
     buffer.append(
         database.escapeColumnNameList(
-            StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+            StringUtil.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
     buffer.append(")");
 
     String pk = buffer.toString();


### PR DESCRIPTION
Liquibase 4 uses Java ServiceLoader rather than a custom scanner previously. This commit supports Liquibase 4 *and* 3.

Changes:
- Support ServiceLoader by automatically generated services by scanning classes in Gradle. Run ServiceLoader prior to build or test.
- Use Apache Commons for join() to reduce dependency on Liquibase (it was renamed between 3 and 4).
- Use Liquibase-Package for Liquibase 3 support. This is the proper way it should have been done.