### PR TITLE
test: verify that remarks are not supported

### DIFF
--- a/src/test/java/liquibase/ext/spanner/SetRemarksTest.java
+++ b/src/test/java/liquibase/ext/spanner/SetRemarksTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.ValidationFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class SetRemarksTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testSetTableRemarksFromYaml() throws Exception {
+    for (String file : new String[] {"set-table-remarks.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains("setTableRemarks is not supported");
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+
+  @Test
+  void testSetColumnRemarksFromYaml() throws Exception {
+    for (String file : new String[] {"set-column-remarks.spanner.yaml"}) {
+      try (Connection con = createConnection();
+          Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+        fail("missing expected validation exception");
+      } catch (ValidationFailedException e) {
+        assertThat(e.getMessage())
+            .contains("setColumnRemarks is not supported");
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/resources/set-column-remarks.spanner.yaml
+++ b/src/test/resources/set-column-remarks.spanner.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - setColumnRemarks:
+          tableName:  Singers
+          columnName: LastName
+          remarks:    Some remarks

--- a/src/test/resources/set-table-remarks.spanner.yaml
+++ b/src/test/resources/set-table-remarks.spanner.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - setTableRemarks:
+          tableName: Singers
+          remarks:   Some remarks


### PR DESCRIPTION
Remarks are only supported by a fixed list of databases in Liquibase, so there is no need to add a custom generator.