### PR TITLE
feat: add support for merge columns

### DIFF
--- a/src/main/java/liquibase/ext/spanner/SpannerMergeColumnsChange.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerMergeColumnsChange.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import liquibase.change.AddColumnConfig;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.change.core.AddColumnChange;
+import liquibase.change.core.DropColumnChange;
+import liquibase.change.core.MergeColumnChange;
+import liquibase.database.Database;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
+import liquibase.structure.core.Column;
+
+/**
+ * Cloud Spanner-specific implementation of {@link MergeColumnChange}. Cloud Spanner requires all
+ * UPDATE and DELETE statements to include a WHERE clause, even when all rows should be
+ * updated/deleted. This feature is a safety precaution against accidental updates/deletes.
+ */
+@DatabaseChange(name = "mergeColumns",
+    description = "Concatenates the values in two columns, joins them by with string, and stores the resulting value in a new column.",
+    priority = ChangeMetaData.PRIORITY_DATABASE)
+public class SpannerMergeColumnsChange extends MergeColumnChange {
+
+  @Override
+  public SqlStatement[] generateStatements(final Database database) {
+    List<SqlStatement> statements = new ArrayList<>();
+
+    AddColumnChange addNewColumnChange = new AddColumnChange();
+    addNewColumnChange.setCatalogName(getCatalogName());
+    addNewColumnChange.setSchemaName(getSchemaName());
+    addNewColumnChange.setTableName(getTableName());
+    final AddColumnConfig columnConfig = new AddColumnConfig();
+    columnConfig.setName(getFinalColumnName());
+    columnConfig.setType(getFinalColumnType());
+    addNewColumnChange.addColumn(columnConfig);
+    statements.addAll(Arrays.asList(addNewColumnChange.generateStatements(database)));
+
+    String updateStatement = "UPDATE "
+        + database.escapeTableName(getCatalogName(), getSchemaName(), getTableName()) + " SET "
+        + database.escapeObjectName(getFinalColumnName(), Column.class) + " = "
+        + database.getConcatSql(database.escapeObjectName(getColumn1Name(), Column.class),
+            "'" + getJoinString() + "'", database.escapeObjectName(getColumn2Name(), Column.class))
+        + " WHERE TRUE";
+    statements.add(new RawSqlStatement(updateStatement));
+
+    DropColumnChange dropColumn1Change = new DropColumnChange();
+    dropColumn1Change.setCatalogName(getCatalogName());
+    dropColumn1Change.setSchemaName(getSchemaName());
+    dropColumn1Change.setTableName(getTableName());
+    dropColumn1Change.setColumnName(getColumn1Name());
+    statements.addAll(Arrays.asList(dropColumn1Change.generateStatements(database)));
+
+    DropColumnChange dropColumn2Change = new DropColumnChange();
+    dropColumn2Change.setCatalogName(getCatalogName());
+    dropColumn2Change.setSchemaName(getSchemaName());
+    dropColumn2Change.setTableName(getTableName());
+    dropColumn2Change.setColumnName(getColumn2Name());
+    statements.addAll(Arrays.asList(dropColumn2Change.generateStatements(database)));
+
+    return statements.toArray(new SqlStatement[statements.size()]);
+  }
+
+}

--- a/src/test/java/liquibase/ext/spanner/MergeColumnsTest.java
+++ b/src/test/java/liquibase/ext/spanner/MergeColumnsTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import java.sql.Connection;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class MergeColumnsTest extends AbstractMockServerTest {
+
+  @BeforeAll
+  static void setupResults() {
+    mockSpanner.putStatementResult(StatementResult.update(
+        Statement
+            .of("UPDATE Singers SET FullName = FirstName || 'some-string' || LastName WHERE TRUE"),
+        10));
+  }
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testMergeSingersFirstNamdAndLastNameFromYaml() throws Exception {
+    String[] expectedSql = new String[] {
+        "ALTER TABLE Singers ADD FullName STRING(500)",
+        "ALTER TABLE Singers DROP COLUMN FirstName",
+        "ALTER TABLE Singers DROP COLUMN LastName",
+      };
+    for (String sql : expectedSql) {
+      addUpdateDdlStatementsResponse(sql);
+    }
+
+    for (String file : new String[] {"merge-singers-firstname-and-lastname.spanner.yaml"}) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    assertThat(mockAdmin.getRequests()).hasSize(expectedSql.length);
+    for (int i = 0; i < expectedSql.length; i++) {
+      assertThat(mockAdmin.getRequests().get(i)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+      UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(i);
+      assertThat(request.getStatementsList()).hasSize(1);
+      assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql[i]);
+    }
+  }
+}

--- a/src/test/resources/merge-singers-firstname-and-lastname.spanner.yaml
+++ b/src/test/resources/merge-singers-firstname-and-lastname.spanner.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1
+     author: spanner-liquibase-tests
+     changes:
+       - mergeColumns:
+          tableName:       Singers
+          column1Name:     FirstName
+          column2Name:     LastName
+          joinString:      some-string
+          finalColumnName: FullName
+          finalColumnType: nvarchar(500)


### PR DESCRIPTION
Adds support for the `mergeColumns` change type. The data from the original columns are copied to the new column using Partitioned DML. This ensures that it will work for columns of any size.

The tests for this change ran into a bug in the emulator that has been reported here: https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/16