### PR TITLE
fix: assign each update a unique id

### DIFF
--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -240,13 +240,13 @@ public class LiquibaseTests {
 
   @Test
   void doEmulatorLoadDataTest() throws Exception {
-    doModifyDataTypeTest(getSpannerEmulator());
+    doLoadDataTest(getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
   void doRealSpannerLoadDataTest() throws Exception {
-    doModifyDataTypeTest(getSpannerReal());
+    doLoadDataTest(getSpannerReal());
   }
 
   void doLoadDataTest(TestHarness.Connection testHarness) throws Exception {

--- a/src/test/resources/add-auto-increment-singers.spanner.yaml
+++ b/src/test/resources/add-auto-increment-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-auto-increment-singers
      author: spanner-liquibase-tests
      changes:
      - addAutoIncrement:

--- a/src/test/resources/add-default-value-singers.spanner.yaml
+++ b/src/test/resources/add-default-value-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-default-value-singers
      author: spanner-liquibase-tests
      changes:
        - addDefaultValue:

--- a/src/test/resources/add-foreign-key-albums-singers.spanner.yaml
+++ b/src/test/resources/add-foreign-key-albums-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-foreign-key-albums-singers
      author: spanner-liquibase-tests
      changes:
        - addForeignKeyConstraint:

--- a/src/test/resources/add-foreign-key-songs-albums.spanner.yaml
+++ b/src/test/resources/add-foreign-key-songs-albums.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-foreign-key-songs-albums
      author: spanner-liquibase-tests
      changes:
        - addForeignKeyConstraint:

--- a/src/test/resources/add-lookup-table-singers-countries.spanner.yaml
+++ b/src/test/resources/add-lookup-table-singers-countries.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-lookup-teable-singers-countries
      author: spanner-liquibase-tests
      changes:
        # Creates a lookup table for the home country of a Singer. This will change the

--- a/src/test/resources/add-not-null-constraint-singers-lastname.spanner.yaml
+++ b/src/test/resources/add-not-null-constraint-singers-lastname.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-not-null-constraint-singers-lastname
      author: spanner-liquibase-tests
      changes:
        - addNotNullConstraint:

--- a/src/test/resources/add-primary-key-singers.spanner.yaml
+++ b/src/test/resources/add-primary-key-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-primary-key-singers
      author: spanner-liquibase-tests
      changes:
        - addPrimaryKey:

--- a/src/test/resources/add-singer-to-concerts-table.spanner.yaml
+++ b/src/test/resources/add-singer-to-concerts-table.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-singer-to-concerts-table
      author: spanner-liquibase-tests
      changes:
        - addColumn:

--- a/src/test/resources/add-singerinfo-to-singers-table.spanner.yaml
+++ b/src/test/resources/add-singerinfo-to-singers-table.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-singerinfo-to-singers-table
      author: spanner-liquibase-tests
      changes:
        - addColumn:

--- a/src/test/resources/add-track-and-lyrics-to-songs-table.spanner.yaml
+++ b/src/test/resources/add-track-and-lyrics-to-songs-table.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-track-and-lyrics-to-songs-table
      author: spanner-liquibase-tests
      changes:
        - addColumn:

--- a/src/test/resources/add-unique-constraint-singers.spanner.yaml
+++ b/src/test/resources/add-unique-constraint-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-add-unique-constraint-singers
      author: spanner-liquibase-tests
      changes:
        - addUniqueConstraint:

--- a/src/test/resources/create-index-singers-first-and-last-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-first-and-last-name.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1-create-index
+     id:     v0.1-create-index-singers-first-and-last-name
      author: spanner-liquibase-tests
      changes:
        - createIndex:

--- a/src/test/resources/create-index-singers-first-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-first-name.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1-create-index
+     id:     v0.1-create-index-singers-first-name
      author: spanner-liquibase-tests
      changes:
        - createIndex:

--- a/src/test/resources/create-index-singers-last-name.spanner.yaml
+++ b/src/test/resources/create-index-singers-last-name.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1-create-index
+     id:     v0.1-create-index-singers-last-name
      author: spanner-liquibase-tests
      changes:
        - createIndex:

--- a/src/test/resources/create-procedure.spanner.yaml
+++ b/src/test/resources/create-procedure.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-create-procedure
      author: spanner-liquibase-tests
      changes:
      - createProcedure:

--- a/src/test/resources/create-sequence.spanner.yaml
+++ b/src/test/resources/create-sequence.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-create-sequence
      author: spanner-liquibase-tests
      changes:
        - createSequence:

--- a/src/test/resources/create-singers-table.spanner.yaml
+++ b/src/test/resources/create-singers-table.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-create-singers-table
      labels: version 0.1
      author: spanner-liquibase-tests
      changes:

--- a/src/test/resources/create-table-with-all-liquibase-types-except-decimal.spanner.yaml
+++ b/src/test/resources/create-table-with-all-liquibase-types-except-decimal.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.3
+     id:     v0.3-create-table-with-all-liquibase-types-except-decimal
      labels: version 0.3
      author: spanner-liquibase-tests
      changes:

--- a/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
+++ b/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.3
+     id:     v0.3-create-table-with-all-liquibase-types
      labels: version 0.3
      author: spanner-liquibase-tests
      changes:

--- a/src/test/resources/create-table-with-all-spanner-types.spanner.yaml
+++ b/src/test/resources/create-table-with-all-spanner-types.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.2
+     id:     v0.2-create-table-with-all-spanner-types
      labels: version 0.2
      author: spanner-liquibase-tests
      changes:

--- a/src/test/resources/create-table-without-pk.spanner.yaml
+++ b/src/test/resources/create-table-without-pk.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-create-table-without-pk
      labels: version 0.1
      author: spanner-liquibase-tests
      changes:

--- a/src/test/resources/create-view.spanner.yaml
+++ b/src/test/resources/create-view.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-create-view
      author: spanner-liquibase-tests
      changes:
      - createView:

--- a/src/test/resources/drop-all-foreign-key-constraints-singers.spanner.yaml
+++ b/src/test/resources/drop-all-foreign-key-constraints-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-all-foreign-key-constraints-singers
      author: spanner-liquibase-tests
      changes:
        - dropAllForeignKeyConstraints:

--- a/src/test/resources/drop-column-singerinfo.spanner.yaml
+++ b/src/test/resources/drop-column-singerinfo.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-column-singerinfo
      author: spanner-liquibase-tests
      changes:
        - dropColumn:

--- a/src/test/resources/drop-columns-track-and-lyrics.spanner.yaml
+++ b/src/test/resources/drop-columns-track-and-lyrics.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-columns-track-and-lyrics
      author: spanner-liquibase-tests
      changes:
        - dropColumn:

--- a/src/test/resources/drop-default-value-singers.spanner.yaml
+++ b/src/test/resources/drop-default-value-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-default-value-singers
      author: spanner-liquibase-tests
      changes:
        - dropDefaultValue:

--- a/src/test/resources/drop-foreign-key.spanner.yaml
+++ b/src/test/resources/drop-foreign-key.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-foreign-key
      author: spanner-liquibase-tests
      changes:
        - dropForeignKeyConstraint:

--- a/src/test/resources/drop-not-null-constraint-singers-lastname.spanner.yaml
+++ b/src/test/resources/drop-not-null-constraint-singers-lastname.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-not-null-constraint-singers-lastname
      author: spanner-liquibase-tests
      changes:
        - dropNotNullConstraint:

--- a/src/test/resources/drop-primary-key-singers.spanner.yaml
+++ b/src/test/resources/drop-primary-key-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-primary-key-singers
      author: spanner-liquibase-tests
      changes:
        - dropPrimaryKey:

--- a/src/test/resources/drop-procedure.spanner.yaml
+++ b/src/test/resources/drop-procedure.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-procedure
      author: spanner-liquibase-tests
      changes:
      - dropProcedure:

--- a/src/test/resources/drop-sequence.spanner.yaml
+++ b/src/test/resources/drop-sequence.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-sequence
      author: spanner-liquibase-tests
      changes:
        - dropSequence:

--- a/src/test/resources/drop-singers-firstname-index-with-tablename.spanner.yaml
+++ b/src/test/resources/drop-singers-firstname-index-with-tablename.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-singers-firstname-index-with-tablename
      author: spanner-liquibase-tests
      changes:
        - dropIndex:

--- a/src/test/resources/drop-singers-lastname-index.spanner.yaml
+++ b/src/test/resources/drop-singers-lastname-index.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-singers-lastname-index
      author: spanner-liquibase-tests
      changes:
        - dropIndex:

--- a/src/test/resources/drop-singers-table.spanner.yaml
+++ b/src/test/resources/drop-singers-table.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-singers-table
      author: spanner-liquibase-tests
      changes:
        - dropTable:

--- a/src/test/resources/drop-unique-constraint-singers.spanner.yaml
+++ b/src/test/resources/drop-unique-constraint-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-unique-constraint-singers
      author: spanner-liquibase-tests
      changes:
        - dropUniqueConstraint:

--- a/src/test/resources/drop-view.spanner.yaml
+++ b/src/test/resources/drop-view.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-drop-view
      author: spanner-liquibase-tests
      changes:
      - dropView:

--- a/src/test/resources/load-data-singers.spanner.yaml
+++ b/src/test/resources/load-data-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     name:     v0.1
+     id:     v0.1-load-data
      author: spanner-liquibase-tests
      changes:
        - loadData:

--- a/src/test/resources/modify-data-type-singers-lastname.spanner.yaml
+++ b/src/test/resources/modify-data-type-singers-lastname.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-modify-data-type-singers-lastname
      author: spanner-liquibase-tests
      changes:
        - modifyDataType:

--- a/src/test/resources/modify-data-type-singers-singerinfo.spanner.yaml
+++ b/src/test/resources/modify-data-type-singers-singerinfo.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-modify-datatype-singers-singerinfo
      author: spanner-liquibase-tests
      changes:
        - modifyDataType:

--- a/src/test/resources/rename-column-singers.spanner.yaml
+++ b/src/test/resources/rename-column-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-rename-column-singers
      author: spanner-liquibase-tests
      changes:
        - renameColumn:

--- a/src/test/resources/rename-sequence.spanner.yaml
+++ b/src/test/resources/rename-sequence.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-rename-sequence
      author: spanner-liquibase-tests
      changes:
        - renameSequence:

--- a/src/test/resources/rename-table-singers.spanner.yaml
+++ b/src/test/resources/rename-table-singers.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-rename-table-singers
      author: spanner-liquibase-tests
      changes:
        - renameTable:

--- a/src/test/resources/rename-view.spanner.yaml
+++ b/src/test/resources/rename-view.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-rename-view
      author: spanner-liquibase-tests
      changes:
      - renameView:

--- a/src/test/resources/set-column-remarks.spanner.yaml
+++ b/src/test/resources/set-column-remarks.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-set-column-remarks
      author: spanner-liquibase-tests
      changes:
        - setColumnRemarks:

--- a/src/test/resources/set-table-remarks.spanner.yaml
+++ b/src/test/resources/set-table-remarks.spanner.yaml
@@ -18,7 +18,7 @@ databaseChangeLog:
      onFail: HALT
      onError: HALT
   - changeSet:
-     id:     v0.1
+     id:     v0.1-set-table-remarks
      author: spanner-liquibase-tests
      changes:
        - setTableRemarks:


### PR DESCRIPTION
Each update file should have its own unique id to ensure that Liquibase does not think that the update has already been executed.

Also, the test case for `loadData` was actually calling the wrong test...

Fixes #48 