### PR TITLE
build: execute unit tests for each commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: "Build and run tests"
           command: |
-            ./gradlew --no-daemon -PtagVersion=${CIRCLE_TAG} build test shadowJar
+            ./gradlew --no-daemon test
       - store_test_results:
           path: build/test-results/test
 
@@ -72,7 +72,7 @@ workflows:
 
   commit:
     jobs:
-      - execute_unit_tests:
+      - execute_unit_tests
       - build_and_test:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,9 @@ workflows:
     jobs:
       - execute_unit_tests
       - build_and_test:
-          when: $GCLOUD_SERVICE_KEY
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
       - publish_github_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: 2.1
 jobs:
 
   # Only execute unit tests
@@ -18,7 +18,7 @@ jobs:
       - store_test_results:
           path: build/test-results/test
 
-  # Build and unit tests
+  # Build and unit and integration tests
   build_and_test:
     machine:
        # Due to test containers
@@ -68,12 +68,13 @@ jobs:
                 ./workspace
 
 workflows:
-  version: 2
+  version: 2.1
 
   commit:
     jobs:
       - execute_unit_tests
       - build_and_test:
+          when: $GCLOUD_SERVICE_KEY
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,19 @@
 version: 2
 jobs:
 
+  # Only execute unit tests
+  execute_unit_tests:
+    machine:
+       image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: "Build and run tests"
+          command: |
+            ./gradlew --no-daemon -PtagVersion=${CIRCLE_TAG} build test shadowJar
+      - store_test_results:
+          path: build/test-results/test
+
   # Build and unit tests
   build_and_test:
     machine:
@@ -59,6 +72,7 @@ workflows:
 
   commit:
     jobs:
+      - execute_unit_tests:
       - build_and_test:
           filters:
             tags:


### PR DESCRIPTION
This enables Circle CI to execute unit tests for each PR, including PR's from forked repositories. It does not execute integration tests against real Spanner.

The current build fails because of the error that is fixed in #49 .