### PR TITLE
Resolved issue with some JARs not being included in the shadowJar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,12 @@ dependencies {
     implementation("org.liquibase:liquibase-core:4.2.0")
     implementation("org.yaml:snakeyaml:1.26")
     implementation("org.apache.commons:commons-lang3:3.11")
-    
+
+    // This shouldn't be necessary!
+    implementation("com.google.api.grpc:grpc-google-cloud-spanner-v1")
+    implementation("com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1")
+    implementation("com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1")
+
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("org.testcontainers:testcontainers:1.15.0")
@@ -86,9 +91,6 @@ dependencies {
     
     // For Spanner mock server testing
     testImplementation(group: 'com.google.cloud', name: 'google-cloud-spanner', classifier: 'tests')
-    testImplementation("com.google.api.grpc:grpc-google-cloud-spanner-v1")
-    testImplementation("com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1")
-    testImplementation("com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1")
     testImplementation(group: 'com.google.api', name: 'gax-grpc', version: '1.60.0', classifier: 'testlib')
 }
 


### PR DESCRIPTION
This isn't a proper fix, however -- this is only necessary with 16.1.0, but not 16.0.0, and it isn't clear why!

I would prefer a different fix, but this change was necessary for the shadowJar to work properly with Liquibase. It will work with 16.0.0 -- this is only with 16.1.0 -- but it's hard to see what's the difference.