### PR TITLE
feat: support load-update-data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-core</artifactId>
-        <version>3.8.9</version>
+        <version>${liquibase.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -25,6 +25,17 @@ public class CloudSpanner extends AbstractJdbcDatabase {
   public java.lang.Integer getDefaultPort() {
     return Integer.valueOf(9010);
   }
+  
+  @Override
+  public String getDateLiteral(final String isoDate) {
+    String literal = super.getDateLiteral(isoDate);
+    if (isDateTime(isoDate)) {
+      literal = "TIMESTAMP " + literal.replace(' ', 'T');
+    } else {
+      literal = "DATE " + literal;
+    }
+    return literal;
+  }
 
   @Override
   public String getCurrentDateTimeFunction() {

--- a/src/main/java/liquibase/ext/spanner/InsertWithSelectGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/InsertWithSelectGenerator.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner;
+
+import java.util.Date;
+import liquibase.database.Database;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.InsertGenerator;
+import liquibase.statement.DatabaseFunction;
+import liquibase.statement.core.InsertStatement;
+
+/** Generator for INSERT statements in the form 'INSERT INTO FOO (..) SELECT ...'. */
+public class InsertWithSelectGenerator extends InsertGenerator {
+
+  @Override
+  public int getPriority() {
+    // This generator should only be used manually.
+    return 0;
+  }
+
+  @Override
+  public Sql[] generateSql(InsertStatement statement, Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    // Generate INSERT INTO (...) header.
+    StringBuilder sql = new StringBuilder();
+    sql.append("INSERT INTO ").append(database.escapeTableName(statement.getCatalogName(),
+        statement.getSchemaName(), statement.getTableName())).append(" (");
+    for (String column : statement.getColumnValues().keySet()) {
+      sql.append(database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(),
+          statement.getTableName(), column)).append(", ");
+    }
+    sql.deleteCharAt(sql.lastIndexOf(" "));
+    int lastComma = sql.lastIndexOf(",");
+    if (lastComma >= 0) {
+      sql.deleteCharAt(lastComma);
+    }
+    sql.append(")");
+
+    // Generate SELECT ... statement.
+    sql.append(" SELECT ");
+    for (String column : statement.getColumnValues().keySet()) {
+      Object newValue = statement.getColumnValues().get(column);
+      if ((newValue == null) || "NULL".equalsIgnoreCase(newValue.toString())) {
+        sql.append("NULL");
+      } else if ((newValue instanceof String)
+          && !looksLikeFunctionCall(((String) newValue), database)) {
+        sql.append(DataTypeFactory.getInstance().fromObject(newValue, database)
+            .objectToSql(newValue, database));
+      } else if (newValue instanceof Date) {
+        sql.append(database.getDateLiteral(((Date) newValue)));
+      } else if (newValue instanceof Boolean) {
+        if (((Boolean) newValue)) {
+          sql.append(DataTypeFactory.getInstance().getTrueBooleanValue(database));
+        } else {
+          sql.append(DataTypeFactory.getInstance().getFalseBooleanValue(database));
+        }
+      } else if (newValue instanceof DatabaseFunction) {
+        sql.append(database.generateDatabaseFunctionValue((DatabaseFunction) newValue));
+      } else {
+        sql.append(newValue);
+      }
+      sql.append(", ");
+    }
+
+    sql.deleteCharAt(sql.lastIndexOf(" "));
+    lastComma = sql.lastIndexOf(",");
+    if (lastComma >= 0) {
+      sql.deleteCharAt(lastComma);
+    }
+
+    return new Sql[] {new UnparsedSql(sql.toString(), getAffectedTable(statement))};
+  }
+
+}

--- a/src/main/java/liquibase/ext/spanner/InsertWithSelectGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/InsertWithSelectGenerator.java
@@ -42,20 +42,27 @@ public class InsertWithSelectGenerator extends InsertGenerator {
     StringBuilder sql = new StringBuilder();
     sql.append("INSERT INTO ").append(database.escapeTableName(statement.getCatalogName(),
         statement.getSchemaName(), statement.getTableName())).append(" (");
+    boolean first = true;
     for (String column : statement.getColumnValues().keySet()) {
+      if (first) {
+        first = false;
+      } else {
+        sql.append(", ");
+      }
       sql.append(database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(),
-          statement.getTableName(), column)).append(", ");
-    }
-    sql.deleteCharAt(sql.lastIndexOf(" "));
-    int lastComma = sql.lastIndexOf(",");
-    if (lastComma >= 0) {
-      sql.deleteCharAt(lastComma);
+          statement.getTableName(), column));
     }
     sql.append(")");
 
     // Generate SELECT ... statement.
     sql.append(" SELECT ");
+    first = true;
     for (String column : statement.getColumnValues().keySet()) {
+      if (first) {
+        first = false;
+      } else {
+        sql.append(", ");
+      }
       Object newValue = statement.getColumnValues().get(column);
       if ((newValue == null) || "NULL".equalsIgnoreCase(newValue.toString())) {
         sql.append("NULL");
@@ -76,13 +83,6 @@ public class InsertWithSelectGenerator extends InsertGenerator {
       } else {
         sql.append(newValue);
       }
-      sql.append(", ");
-    }
-
-    sql.deleteCharAt(sql.lastIndexOf(" "));
-    lastComma = sql.lastIndexOf(",");
-    if (lastComma >= 0) {
-      sql.deleteCharAt(lastComma);
     }
 
     return new Sql[] {new UnparsedSql(sql.toString(), getAffectedTable(statement))};

--- a/src/main/java/liquibase/ext/spanner/SpannerInsertOrUpdateGenerator.java
+++ b/src/main/java/liquibase/ext/spanner/SpannerInsertOrUpdateGenerator.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner;
+
+import java.util.ArrayList;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.InsertOrUpdateGenerator;
+import liquibase.statement.core.InsertOrUpdateStatement;
+
+public class SpannerInsertOrUpdateGenerator extends InsertOrUpdateGenerator {
+  @Override
+  public boolean supports(InsertOrUpdateStatement statement, Database database) {
+    return database instanceof CloudSpanner;
+  }
+
+  @Override
+  public Sql[] generateSql(InsertOrUpdateStatement insertOrUpdateStatement, Database database,
+      SqlGeneratorChain sqlGeneratorChain) {
+    // Cloud Spanner does not have an UPSERT / MERGE DML statement, so we will generate both an
+    // INSERT and an UPDATE statement. The INSERT statement will check whether the record already
+    // exists, and only insert it in that case. The record is always updated.
+    //
+    // The most efficient way to do this in Cloud Spanner would be to use an InsertOrUpdate
+    // mutation. That is however not supported through Liquibase, as it requires the update to use
+    // SQL.
+    ArrayList<Sql> sqlList = new ArrayList<>(2);
+    if (!insertOrUpdateStatement.getOnlyUpdate()) {
+      sqlList.add(
+          new UnparsedSql(getInsertStatement(insertOrUpdateStatement, database, sqlGeneratorChain),
+              "", getAffectedTable(insertOrUpdateStatement)));
+    }
+
+    String whereClause = getWhereClause(insertOrUpdateStatement, database);
+    try {
+      String update =
+          getUpdateStatement(insertOrUpdateStatement, database, whereClause, sqlGeneratorChain);
+      if (update.endsWith("\n") && update.length() > 1) {
+        update = update.substring(0, update.length() - 1);
+      }
+      if (update.endsWith(";") && update.length() > 1) {
+        update = update.substring(0, update.length() - 1);
+      }
+      sqlList.add(new UnparsedSql(update, "", getAffectedTable(insertOrUpdateStatement)));
+    } catch (LiquibaseException e) {
+    }
+    return sqlList.toArray(new Sql[sqlList.size()]);
+  }
+
+  @Override
+  protected String getInsertStatement(InsertOrUpdateStatement insertOrUpdateStatement,
+      Database database, SqlGeneratorChain sqlGeneratorChain) {
+    InsertWithSelectGenerator insertGenerator = new InsertWithSelectGenerator();
+    StringBuffer sql = new StringBuffer(
+        insertGenerator.generateSql(insertOrUpdateStatement, database, sqlGeneratorChain)[0]
+            .toSql());
+    sql
+        .append(" FROM UNNEST([1])") // only SELECT statements with a FROM may have a WHERE clause.
+        .append(" WHERE NOT EXISTS (") // only insert if the row does not already exist.
+        .append("SELECT ")
+        .append(insertOrUpdateStatement.getPrimaryKey())
+        .append(" FROM ")
+        .append(database.escapeTableName(insertOrUpdateStatement.getCatalogName(),
+            insertOrUpdateStatement.getSchemaName(), insertOrUpdateStatement.getTableName()))
+        .append(" WHERE ")
+        .append(getWhereClause(insertOrUpdateStatement, database))
+        .append(")");
+
+    return sql.toString();
+  }
+
+  @Override
+  protected String getRecordCheck(InsertOrUpdateStatement insertOrUpdateStatement,
+      Database database, String whereClause) {
+    return "";
+  }
+
+  @Override
+  protected String getElse(Database database) {
+    return "";
+  }
+}

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -18,7 +18,10 @@ package com.google.spanner.liquibase;
 
 import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -277,6 +280,71 @@ public class LiquibaseTests {
             assertThat(rs.getString("Description")).isEqualTo("This is a CLOB description " + index);
             assertThat(rs.getBytes("SingerInfo")).isEqualTo(ByteArray.copyFrom("singerinfo " + index).toByteArray());
             assertThat(rs.getBoolean("AnyGood")).isEqualTo(index %2 == 0);
+          }
+          assertThat(index).isEqualTo(3);
+        }
+      } finally {
+        statement.execute("START BATCH DDL");
+        statement.execute("DROP TABLE Singers");
+        statement.execute("RUN BATCH");
+      }
+    }
+  }
+
+  @Test
+  void doEmulatorLoadUpdateDataTest() throws Exception {
+    doLoadUpdateDataTest(getSpannerEmulator());
+  }
+
+  @Test
+  @Tag("integration")
+  void doRealSpannerLoadUpdateDataTest() throws Exception {
+    doLoadUpdateDataTest(getSpannerReal());
+  }
+
+  void doLoadUpdateDataTest(TestHarness.Connection testHarness) throws Exception {
+    Connection con = testHarness.getJDBCConnection();
+    try (Statement statement = con.createStatement()) {
+      statement.execute("START BATCH DDL");
+      statement.execute("CREATE TABLE Singers ("
+          + "SingerId INT64,"
+          + "Name STRING(100),"
+          + "Description STRING(MAX),"
+          + "SingerInfo BYTES(MAX),"
+          + "AnyGood BOOL,"
+          + "Birthdate DATE,"
+          + "LastConcertTimestamp TIMESTAMP,"
+          + "ExternalID STRING(36),"
+          + ") PRIMARY KEY (SingerId)");
+      statement.execute("RUN BATCH");
+      // Insert one record that will be updated by Liquibase.
+      CloudSpannerJdbcConnection cs = con.unwrap(CloudSpannerJdbcConnection.class);
+      boolean wasAutoCommit = cs.getAutoCommit();
+      cs.setAutoCommit(true);
+      cs.write(Mutation.newInsertBuilder("Singers")
+          .set("SingerId").to(2L)
+          .set("Name").to("Some initial name")
+          .set("Description").to("Some initial description")
+          .set("SingerInfo").to(ByteArray.copyFrom("Some initial singer info"))
+          .set("AnyGood").to(false)
+          .set("Birthdate").to(Date.fromYearMonthDay(2000, 1, 1))
+          .set("LastConcertTimestamp").to(Timestamp.ofTimeMicroseconds(12345678))
+          .set("ExternalId").to("some initial external id")
+          .build());
+      cs.setAutoCommit(wasAutoCommit);
+      try {
+        Liquibase liquibase = getLiquibase(testHarness, "load-update-data-singers.spanner.yaml");
+        liquibase.update(new Contexts("test"));
+        
+        try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
+          int index = 0;
+          while (rs.next()) {
+            index++;
+            assertThat(rs.getLong("SingerId")).isEqualTo(index);
+            assertThat(rs.getString("Name")).isEqualTo("Name " + index);
+            assertThat(rs.getString("Description")).isEqualTo("Description " + index);
+            assertThat(rs.getBytes("SingerInfo")).isNull();
+            assertThat(rs.getBoolean("AnyGood")).isEqualTo(index % 2 == 0);
           }
           assertThat(index).isEqualTo(3);
         }

--- a/src/test/java/liquibase/ext/spanner/LoadUpdateDataTest.java
+++ b/src/test/java/liquibase/ext/spanner/LoadUpdateDataTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import java.sql.Connection;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Iterator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class LoadUpdateDataTest extends AbstractMockServerTest {
+  private static final String INSERT =
+      "INSERT INTO Singers (SingerId, Name, Description, SingerInfo, AnyGood, Birthdate, LastConcertTimestamp, ExternalID) "
+          + "SELECT @id, @name, @description, @singerinfo, @anygood, @birthdate, @lastconcert, @externalid FROM UNNEST([1]) "
+          + "WHERE NOT EXISTS (SELECT SingerId FROM Singers WHERE SingerId = @id)";
+
+  private static final String UPDATE = "UPDATE Singers SET "
+      + "AnyGood = @anygood, Birthdate = @birthdate, Description = @description, "
+      + "ExternalID = @externalid, LastConcertTimestamp = @lastconcert, "
+      + "Name = @name, SingerInfo = @singerinfo WHERE SingerId = @id";
+
+  @BeforeAll
+  static void setupResults() throws ParseException {
+    Date[] birthdates = new Date[] {Date.fromYearMonthDay(1997, 10, 1),
+        Date.fromYearMonthDay(2000, 2, 29), Date.fromYearMonthDay(1980, 12, 1)};
+    // Liquibase will always use the default System timezone, so we need to read the timestamps in
+    // the local timezone first, and then convert to UTC. This means that the actual date that will
+    // be loaded into the database will depend on the timezone of the local system where the update
+    // is executed...
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    java.sql.Timestamp[] localConcertDates = new java.sql.Timestamp[] {
+        new java.sql.Timestamp(formatter.parse("2019-12-31T10:30:00").getTime()),
+        new java.sql.Timestamp(formatter.parse("2020-07-09T22:45:10").getTime()),
+        new java.sql.Timestamp(formatter.parse("2018-01-19T01:00:01").getTime()),};
+    Timestamp[] concertDates = new Timestamp[] {Timestamp.of(localConcertDates[0]),
+        Timestamp.of(localConcertDates[1]), Timestamp.of(localConcertDates[2]),};
+    String[] uuids = new String[] {"'5b4beb53-27a6-4b7f-92ac-19c7c95353da'",
+        "'9bff9ea5-024c-49b4-8f24-46570e515aff'", "'f1f4c7d2-9ae8-4fdb-94f6-7931736c9cd1'",};
+
+    CloudSpanner db = new CloudSpanner();
+    for (int id : new int[] {1, 2, 3}) {
+      String insert =
+          INSERT.replaceAll("@id", String.valueOf(id)).replaceAll("@name", "'Name " + id + "'")
+              .replaceAll("@description", "'Description " + id + "'")
+              .replaceAll("@singerinfo", "NULL")
+              .replaceAll("@anygood", String.valueOf(id % 2 == 0).toUpperCase())
+              .replaceAll("@birthdate",
+                  db.getDateLiteral(
+                      new java.sql.Date(Date.toJavaUtilDate(birthdates[id - 1]).getTime())))
+              .replaceAll("@lastconcert", db.getDateLiteral(concertDates[id - 1].toSqlTimestamp()))
+              .replaceAll("@externalid", uuids[id - 1]);
+      mockSpanner.putStatementResult(StatementResult.update(Statement.of(insert), 1L));
+      String update =
+          UPDATE.replaceAll("@id", String.valueOf(id)).replaceAll("@name", "'Name " + id + "'")
+              .replaceAll("@description", "'Description " + id + "'")
+              .replaceAll("@singerinfo", "NULL")
+              .replaceAll("@anygood", String.valueOf(id % 2 == 0).toUpperCase())
+              .replaceAll("@birthdate",
+                  db.getDateLiteral(
+                      new java.sql.Date(Date.toJavaUtilDate(birthdates[id - 1]).getTime())))
+              .replaceAll("@lastconcert", db.getDateLiteral(concertDates[id - 1].toSqlTimestamp()))
+              .replaceAll("@externalid", uuids[id - 1]);
+      mockSpanner.putStatementResult(StatementResult.update(Statement.of(update), 1L));
+    }
+  }
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testLoadUpdateDataFromYaml() throws Exception {
+    for (String file : new String[] {"load-update-data-singers.spanner.yaml"}) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.update(new Contexts("test"));
+      }
+    }
+
+    Iterable<ExecuteSqlRequest> sqlRequests =
+        Iterables.filter(mockSpanner.getRequests(), ExecuteSqlRequest.class);
+    Iterator<ExecuteSqlRequest> requests =
+        Iterables.filter(sqlRequests, new Predicate<ExecuteSqlRequest>() {
+          @Override
+          public boolean apply(ExecuteSqlRequest request) {
+            return request.getSql().startsWith("INSERT INTO Singers")
+                || request.getSql().startsWith("UPDATE Singers");
+          }
+        }).iterator();
+    for (int id : new int[] {1, 2, 3}) {
+      assertThat(requests.hasNext()).isTrue();
+      ExecuteSqlRequest request = requests.next();
+      assertThat(request.getSql()).startsWith("INSERT");
+      assertThat(request.getSql())
+          .endsWith("WHERE NOT EXISTS (SELECT SingerId FROM Singers WHERE SingerId = " + id + ")");
+
+      assertThat(requests.hasNext()).isTrue();
+      request = requests.next();
+      assertThat(request.getSql()).startsWith("UPDATE");
+      assertThat(request.getSql()).endsWith("WHERE SingerId = " + id);
+    }
+    assertThat(requests.hasNext()).isFalse();
+  }
+}

--- a/src/test/resources/load-update-data-singers.spanner.yaml
+++ b/src/test/resources/load-update-data-singers.spanner.yaml
@@ -46,7 +46,11 @@ databaseChangeLog:
            - column:
               header: Info
               name:   SingerInfo
-              # BLOB literals are not treated differently from strings in Liquibase, so these are all NULLs in the tests.
+              # LoadUpdateDataChange uses SQL literals instead of PreparedStatement.
+              # Cloud Spanner does support BLOB (BYTES) literals, but Liquibase does
+              # not distinguish them during the SQL generation. That means that they
+              # are generated as normal strings, which again is not supported by
+              # Cloud Spanner. These are therefore NULL in the test data for this test.
               type:   BLOB
            - column:
               header: Good

--- a/src/test/resources/load-update-data-singers.spanner.yaml
+++ b/src/test/resources/load-update-data-singers.spanner.yaml
@@ -1,0 +1,68 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+     onFail: HALT
+     onError: HALT
+  - changeSet:
+     id:     v0.1-load-update-data
+     author: spanner-liquibase-tests
+     changes:
+       - loadUpdateData:
+          tableName: Singers
+          usePreparedStatements: true
+          separator: ;
+          relativeToChangelogFile: true
+          file: singers-update.csv
+          encoding: UTF-8
+          quotchar:  ''''
+          primaryKey: SingerId
+          columns:
+           - column:
+              header: Id
+              name:   SingerId
+              type:   NUMERIC
+           - column:
+              header: Name
+              name:   Name
+              type:   STRING
+           - column:
+              header: Desc
+              name:   Description
+              type:   CLOB
+           - column:
+              header: Info
+              name:   SingerInfo
+              # BLOB literals are not treated differently from strings in Liquibase, so these are all NULLs in the tests.
+              type:   BLOB
+           - column:
+              header: Good
+              name:   AnyGood
+              type:   BOOLEAN
+           - column:
+              header: Birthdate
+              name:   Birthdate
+              type:   DATE
+           - column:
+              header: LastConcert
+              name:   LastConcertTimestamp
+              type:   DATE
+           - column:
+              header: UUID
+              name:   ExternalID
+              # UUID is currently not supported by the JDBC driver
+              # type:   UUID
+              type:   STRING

--- a/src/test/resources/singers-update.csv
+++ b/src/test/resources/singers-update.csv
@@ -1,0 +1,4 @@
+Id;Name;Desc;Info;Good;Birthdate;LastConcert;UUID
+1;Name 1;Description 1;NULL;FALSE;1997-10-01;2019-12-31T10:30:00;5b4beb53-27a6-4b7f-92ac-19c7c95353da
+2;Name 2;Description 2;NULL;TRUE;2000-02-29;2020-07-09T22:45:10;9bff9ea5-024c-49b4-8f24-46570e515aff
+3;Name 3;Description 3;NULL;FALSE;1980-12-01;2018-01-19T01:00:01;f1f4c7d2-9ae8-4fdb-94f6-7931736c9cd1


### PR DESCRIPTION
Adds support for the load-update-data change type. This change type normally uses an UPSERT / MERGE statement. Cloud Spanner does not support that for DML statements, and Liquibase does not support using anything else than SQL for this change type. That means that the change type for Cloud Spanner will always generate two statements for each row that will be inserted/updated:
1. An optional `INSERT` statement that will check whether the row already exists.
1. An `UPDATE` statement that always updates the row (even if it was just inserted).

The more efficient way to do this would be to use an `InsertOrUpdate` mutation in Cloud Spanner. There is however currently no way to trigger that through SQL.