### PR TITLE
Remove logback from shadowJar and configure default logging for gRPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,7 @@ dependencies {
 
     // Cloud Spanner related
     implementation platform('com.google.cloud:libraries-bom:16.1.0')
-    
     implementation("com.google.cloud:google-cloud-spanner-jdbc")
-    implementation("com.google.cloud:google-cloud-logging-logback")
 
     // Liquibase Core - needed for testing and docker container
     implementation("org.liquibase:liquibase-core:4.2.0")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <logger name="io.grpc.netty.shaded" level="INFO" /> 
+</configuration>


### PR DESCRIPTION
When running with the Spanner plugin gRPC was logging at a DEBUG level.

This change -
- Removes the logback dependency. It isn't clear why it is needed. It isn't needed when running as an extension, and I don't expect it's needed for tests?
- Apply a configuration for logback.xml (which seems to be used by Liquibase) that configures gRPC at INFO level.