### PR TITLE
test: use liquibase test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 .idea/
 .vscode/
 /target/
+liquibase-spanner.iml

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
     id "java"
+    id "groovy"
     id "com.google.cloud.tools.jib" version "2.7.0"
     id "com.github.johnrengelman.shadow" version "6.0.0"
     id "com.github.harbby.gradle.serviceloader" version "1.1.2"
@@ -80,6 +81,15 @@ dependencies {
     testImplementation("com.google.truth:truth:1.0.1")
     testImplementation("org.mockito:mockito-core:1.10.19")
 
+    // For using the Liquibase test harness
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.liquibase:liquibase-test-harness:1.0.0'
+    testImplementation('org.codehaus.groovy:groovy-all:2.5.7') {
+        exclude module: 'org.codehaus.groovy:groovy-testng'
+        exclude module: 'org.codehaus.groovy:groovy-swing'
+    }
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+
     // For testing runtime
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     
@@ -100,6 +110,15 @@ test {
   }
 }
 
+task liquibaseHarnessTest(type: Test) {
+
+    // serviceLoaderBuild is necessary for Liquibase to find the extensions
+    dependsOn "serviceLoaderBuild"
+
+    // Use JUnit4 for Liquibase harness tests.
+    useJUnit {
+    }
+}
 
 // Run integration tests (against live Spanner)
 //

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-
+    
     <!-- Spanner test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -190,9 +190,9 @@
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
-
+    
   </dependencies>
-
+  
   <build>
     <pluginManagement>
       <plugins>
@@ -244,21 +244,21 @@
           <artifactId>maven-source-plugin</artifactId>
           <version>3.2.1</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.6</version>
-        </plugin>
-        <plugin>
-          <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
-          <artifactId>serviceloader-maven-plugin</artifactId>
-          <version>1.1.0</version>
-        </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.1.1</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+          </plugin>
+          <plugin>
+            <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+            <artifactId>serviceloader-maven-plugin</artifactId>
+            <version>1.1.0</version>
+          </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -101,16 +101,19 @@
       <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.5.14</version>
+      <version>2.5.7</version>
       <type>pom</type>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>
           <artifactId>groovy-testng</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-swing</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -118,15 +121,8 @@
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <version>1.3-groovy-2.5</version>
-      <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.mattbertolini</groupId>
-      <artifactId>liquibase-slf4j</artifactId>
-      <version>4.0.0</version>
-      <scope>test</scope>
-    </dependency>
-        
+
     <!-- Generic test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,20 @@
     <truth.version>1.0.1</truth.version>
     <mockito.version>1.10.19</mockito.version>
   </properties>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>bintray</id>
+      <name>Groovy Bintray</name>
+      <url>https://dl.bintray.com/groovy/maven</url>
+      <releases>
+        <!-- avoid automatic updates -->
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>
@@ -86,6 +100,34 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
+    </dependency>
+
+    <!-- Liquibase test dependencies -->
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-test-harness</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>2.5.7</version>
+      <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-testng</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-swing</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.spockframework</groupId>
+      <artifactId>spock-core</artifactId>
+      <version>1.3-groovy-2.5</version>
     </dependency>
 
     <!-- Generic test dependencies -->
@@ -118,7 +160,7 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-    
+
     <!-- Spanner test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -148,9 +190,9 @@
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
-    
+
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>
@@ -176,36 +218,54 @@
           <version>3.0.0-M4</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5</version>
-            <configuration>
-              <source>${java.version}</source>
-              <target>${java.version}</target>
-            </configuration>
+          <version>3.8.0</version>
+          <configuration>
+            <compilerId>groovy-eclipse-compiler</compilerId>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-eclipse-compiler</artifactId>
+              <version>3.3.0-01</version>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-eclipse-batch</artifactId>
+              <version>2.5.7-01</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.2.1</version>
         </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.1</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-          </plugin>
-          <plugin>
-            <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
-            <artifactId>serviceloader-maven-plugin</artifactId>
-            <version>1.1.0</version>
-          </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+        </plugin>
+        <plugin>
+          <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+          <artifactId>serviceloader-maven-plugin</artifactId>
+          <version>1.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <liquibase.version>3.8.9</liquibase.version>
+    <liquibase.version>4.3.1</liquibase.version>
     <snakeyaml.version>1.26</snakeyaml.version>
 
     <gax-grpc.version>1.60.0</gax-grpc.version>
@@ -61,20 +61,6 @@
     <truth.version>1.0.1</truth.version>
     <mockito.version>1.10.19</mockito.version>
   </properties>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>bintray</id>
-      <name>Groovy Bintray</name>
-      <url>https://dl.bintray.com/groovy/maven</url>
-      <releases>
-        <!-- avoid automatic updates -->
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>
@@ -101,26 +87,30 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
     </dependency>
-
+    
     <!-- Liquibase test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <version>4.13.1</version>
+    </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-test-harness</artifactId>
       <version>1.0.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.5.7</version>
+      <version>2.5.14</version>
       <type>pom</type>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>
           <artifactId>groovy-testng</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-swing</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -128,8 +118,15 @@
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <version>1.3-groovy-2.5</version>
+      <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.mattbertolini</groupId>
+      <artifactId>liquibase-slf4j</artifactId>
+      <version>4.0.0</version>
+      <scope>test</scope>
+    </dependency>
+        
     <!-- Generic test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -219,52 +216,37 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-          <configuration>
-            <compilerId>groovy-eclipse-compiler</compilerId>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
-          </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.codehaus.groovy</groupId>
-              <artifactId>groovy-eclipse-compiler</artifactId>
-              <version>3.3.0-01</version>
-            </dependency>
-            <dependency>
-              <groupId>org.codehaus.groovy</groupId>
-              <artifactId>groovy-eclipse-batch</artifactId>
-              <version>2.5.7-01</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.2.1</version>
         </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.1</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-          </plugin>
-          <plugin>
-            <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
-            <artifactId>serviceloader-maven-plugin</artifactId>
-            <version>1.1.0</version>
-          </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+        </plugin>
+        <plugin>
+          <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+          <artifactId>serviceloader-maven-plugin</artifactId>
+          <version>1.1.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+            <optimize>true</optimize>
+            <debug>true</debug>
+            <encoding>${project.build.sourceEncoding}</encoding>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -293,6 +275,23 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.12.1</version>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>addSources</goal>
+                      <goal>addTestSources</goal>
+                      <goal>compile</goal>
+                      <goal>compileTests</goal>
+                      <goal>removeStubs</goal>
+                      <goal>removeTestStubs</goal>
+                  </goals>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>
@@ -371,5 +370,4 @@
       </repositories>
     </profile>
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
       <version>4.13.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
@@ -116,11 +116,13 @@
           <artifactId>groovy-swing</artifactId>
         </exclusion>
       </exclusions>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <version>1.3-groovy-2.5</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Generic test dependencies -->

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -15,8 +15,9 @@ package liquibase.ext.spanner;
 
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
+import liquibase.structure.core.Column;
 
-public class CloudSpanner extends AbstractJdbcDatabase {
+public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner {
 
   public CloudSpanner() {
   }
@@ -25,7 +26,7 @@ public class CloudSpanner extends AbstractJdbcDatabase {
   public java.lang.Integer getDefaultPort() {
     return Integer.valueOf(9010);
   }
-  
+
   @Override
   public String getDateLiteral(final String isoDate) {
     String literal = super.getDateLiteral(isoDate);

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner;
 
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
-import liquibase.structure.core.Column;
 
 public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner {
 

--- a/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
@@ -1,0 +1,6 @@
+package liquibase.ext.spanner;
+
+import liquibase.database.Database;
+
+public interface ICloudSpanner extends Database {
+}

--- a/src/main/java/liquibase/ext/spanner/change/AddColumnChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/AddColumnChangeSpanner.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner.change;
+
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.change.core.AddColumnChange;
+import liquibase.change.core.AddForeignKeyConstraintChange;
+import liquibase.change.core.AddLookupTableChange;
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
+import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Column;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@DatabaseChange(name="addColumn", description = "Adds a new column to an existing table", priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "table")
+public class AddColumnChangeSpanner extends AddColumnChange {
+
+  @Override
+  public boolean supports(Database database) {
+    return (database instanceof ICloudSpanner);
+  }
+
+  @Override
+  public SqlStatement[] generateStatements(Database database) {
+    SqlStatement[] statements = super.generateStatements(database);
+    for (SqlStatement statement : statements) {
+      if (statement instanceof UpdateStatement) {
+        UpdateStatement updateStatement = (UpdateStatement) statement;
+        if (updateStatement.getWhereClause() == null) {
+          updateStatement.setWhereClause("TRUE");
+        }
+      }
+    }
+    return statements;
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/change/AddColumnChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/AddColumnChangeSpanner.java
@@ -16,18 +16,10 @@ package liquibase.ext.spanner.change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.change.core.AddColumnChange;
-import liquibase.change.core.AddForeignKeyConstraintChange;
-import liquibase.change.core.AddLookupTableChange;
 import liquibase.database.Database;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawSqlStatement;
 import liquibase.statement.core.UpdateStatement;
-import liquibase.structure.core.Column;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @DatabaseChange(name="addColumn", description = "Adds a new column to an existing table", priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "table")
 public class AddColumnChangeSpanner extends AddColumnChange {

--- a/src/main/java/liquibase/ext/spanner/change/AddLookupTableChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/AddLookupTableChangeSpanner.java
@@ -22,6 +22,7 @@ import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.change.core.AddLookupTableChange;
 import liquibase.database.Database;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.core.Column;
@@ -36,7 +37,7 @@ public class AddLookupTableChangeSpanner extends AddLookupTableChange {
 
   @Override
   public boolean supports(Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 
   public SqlStatement[] generateStatements(Database database) {

--- a/src/main/java/liquibase/ext/spanner/change/AddLookupTableChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/AddLookupTableChangeSpanner.java
@@ -21,7 +21,6 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.change.core.AddLookupTableChange;
 import liquibase.database.Database;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawSqlStatement;

--- a/src/main/java/liquibase/ext/spanner/change/DropAllForeignKeyConstraintsChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/DropAllForeignKeyConstraintsChangeSpanner.java
@@ -16,6 +16,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.statement.SqlStatement;
 
 @DatabaseChange(name="dropAllForeignKeyConstraints", description = "Drops all foreign key constraints for a table", priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "table")
@@ -23,7 +24,7 @@ public class DropAllForeignKeyConstraintsChangeSpanner extends DropAllForeignKey
 
   @Override
   public boolean supports(Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
   
   public SqlStatement[] generateStatements(Database database) {

--- a/src/main/java/liquibase/ext/spanner/change/DropAllForeignKeyConstraintsChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/DropAllForeignKeyConstraintsChangeSpanner.java
@@ -15,7 +15,6 @@ import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.statement.SqlStatement;
 

--- a/src/main/java/liquibase/ext/spanner/change/StandardChangeLogHistoryServiceSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/StandardChangeLogHistoryServiceSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.change;
 import liquibase.changelog.StandardChangeLogHistoryService;
 import liquibase.database.Database;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class StandardChangeLogHistoryServiceSpanner extends StandardChangeLogHistoryService {
 
@@ -23,7 +24,7 @@ public class StandardChangeLogHistoryServiceSpanner extends StandardChangeLogHis
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/change/StandardChangeLogHistoryServiceSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/StandardChangeLogHistoryServiceSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.change;
 
 import liquibase.changelog.StandardChangeLogHistoryService;
 import liquibase.database.Database;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class StandardChangeLogHistoryServiceSpanner extends StandardChangeLogHistoryService {

--- a/src/main/java/liquibase/ext/spanner/datatype/BigIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BigIntTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BigIntType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class BigIntTypeSpanner extends BigIntType {
   private static final DatabaseDataType INT64 = new DatabaseDataType("INT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return INT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/BigIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BigIntTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BigIntType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class BigIntTypeSpanner extends BigIntType {

--- a/src/main/java/liquibase/ext/spanner/datatype/BlobTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BlobTypeSpanner.java
@@ -4,6 +4,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BlobType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** BLOB is translated to BYTES(MAX) */
 public class BlobTypeSpanner extends BlobType {
@@ -11,12 +12,12 @@ public class BlobTypeSpanner extends BlobType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return BLOB;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/BlobTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BlobTypeSpanner.java
@@ -3,7 +3,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BlobType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** BLOB is translated to BYTES(MAX) */

--- a/src/main/java/liquibase/ext/spanner/datatype/BoolTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BoolTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BooleanType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class BoolTypeSpanner extends BooleanType {
   private static final DatabaseDataType BOOL = new DatabaseDataType("BOOL");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return BOOL;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/BoolTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/BoolTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.BooleanType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class BoolTypeSpanner extends BooleanType {

--- a/src/main/java/liquibase/ext/spanner/datatype/CharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/CharTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.CharType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** CHAR(n) is translated to STRING(n). */

--- a/src/main/java/liquibase/ext/spanner/datatype/CharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/CharTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.CharType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** CHAR(n) is translated to STRING(n). */
 public class CharTypeSpanner extends CharType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return new DatabaseDataType("STRING(" + getParameters()[0] + ")");
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/ClobTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ClobTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.ClobType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** CLOB is translated to STRING(MAX). */

--- a/src/main/java/liquibase/ext/spanner/datatype/ClobTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ClobTypeSpanner.java
@@ -17,6 +17,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.ClobType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** CLOB is translated to STRING(MAX). */
 public class ClobTypeSpanner extends ClobType {
@@ -24,12 +25,12 @@ public class ClobTypeSpanner extends ClobType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return CLOB;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/DecimalTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/DecimalTypeSpanner.java
@@ -4,6 +4,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DecimalType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** DECIMAL is translated to NUMERIC. */
 public class DecimalTypeSpanner extends DecimalType {
@@ -11,12 +12,12 @@ public class DecimalTypeSpanner extends DecimalType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return DECIMAL;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/DecimalTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/DecimalTypeSpanner.java
@@ -3,7 +3,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DecimalType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** DECIMAL is translated to NUMERIC. */

--- a/src/main/java/liquibase/ext/spanner/datatype/DoubleTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/DoubleTypeSpanner.java
@@ -4,18 +4,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DoubleType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class DoubleTypeSpanner extends DoubleType {
   private static final DatabaseDataType FLOAT64 = new DatabaseDataType("FLOAT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return FLOAT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/DoubleTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/DoubleTypeSpanner.java
@@ -3,7 +3,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DoubleType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class DoubleTypeSpanner extends DoubleType {

--- a/src/main/java/liquibase/ext/spanner/datatype/FloatTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/FloatTypeSpanner.java
@@ -3,7 +3,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.FloatType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class FloatTypeSpanner extends FloatType {

--- a/src/main/java/liquibase/ext/spanner/datatype/FloatTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/FloatTypeSpanner.java
@@ -4,18 +4,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.FloatType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class FloatTypeSpanner extends FloatType {
   private static final DatabaseDataType FLOAT64 = new DatabaseDataType("FLOAT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return FLOAT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/IntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/IntTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.IntType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class IntTypeSpanner extends IntType {

--- a/src/main/java/liquibase/ext/spanner/datatype/IntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/IntTypeSpanner.java
@@ -17,17 +17,18 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.IntType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class IntTypeSpanner extends IntType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return new DatabaseDataType("INT64");
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/MediumIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/MediumIntTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.MediumIntType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class MediumIntTypeSpanner extends MediumIntType {
   private static final DatabaseDataType INT64 = new DatabaseDataType("INT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return INT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/MediumIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/MediumIntTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.MediumIntType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class MediumIntTypeSpanner extends MediumIntType {

--- a/src/main/java/liquibase/ext/spanner/datatype/ModifyDataTypeGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ModifyDataTypeGeneratorSpanner.java
@@ -26,6 +26,7 @@ import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGenerator;
@@ -37,7 +38,7 @@ public class ModifyDataTypeGeneratorSpanner extends ModifyDataTypeGenerator {
 
   @Override
   public boolean supports(ModifyDataTypeStatement statement, Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/datatype/ModifyDataTypeGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ModifyDataTypeGeneratorSpanner.java
@@ -25,7 +25,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;

--- a/src/main/java/liquibase/ext/spanner/datatype/NCharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NCharTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NCharType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** NCHAR(n) is translated to STRING(n). */
 public class NCharTypeSpanner extends NCharType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return new DatabaseDataType("STRING(" + getParameters()[0] + ")");
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/NCharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NCharTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NCharType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** NCHAR(n) is translated to STRING(n). */

--- a/src/main/java/liquibase/ext/spanner/datatype/NVarcharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NVarcharTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NVarcharType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** NVARCHAR(n) is translated to STRING(n). */
 public class NVarcharTypeSpanner extends NVarcharType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return new DatabaseDataType("STRING(" + getParameters()[0] + ")");
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/NVarcharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NVarcharTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NVarcharType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** NVARCHAR(n) is translated to STRING(n). */

--- a/src/main/java/liquibase/ext/spanner/datatype/NumberTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NumberTypeSpanner.java
@@ -4,18 +4,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NumberType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class NumberTypeSpanner extends NumberType {
   private static final DatabaseDataType NUMERIC = new DatabaseDataType("NUMERIC");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return NUMERIC;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/NumberTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/NumberTypeSpanner.java
@@ -3,7 +3,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.NumberType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class NumberTypeSpanner extends NumberType {

--- a/src/main/java/liquibase/ext/spanner/datatype/SmallIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/SmallIntTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.SmallIntType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class SmallIntTypeSpanner extends SmallIntType {

--- a/src/main/java/liquibase/ext/spanner/datatype/SmallIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/SmallIntTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.SmallIntType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class SmallIntTypeSpanner extends SmallIntType {
   private static final DatabaseDataType INT64 = new DatabaseDataType("INT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return INT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/TimeTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TimeTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.TimeType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /**

--- a/src/main/java/liquibase/ext/spanner/datatype/TimeTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TimeTypeSpanner.java
@@ -17,6 +17,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.TimeType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /**
  * Cloud Spanner does not have a data type that only stores time information. The best possible
@@ -27,12 +28,12 @@ public class TimeTypeSpanner extends TimeType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return TIME;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/TimestampTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TimestampTypeSpanner.java
@@ -17,17 +17,18 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DateTimeType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class TimestampTypeSpanner extends DateTimeType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return new DatabaseDataType("TIMESTAMP");
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/TimestampTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TimestampTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.DateTimeType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class TimestampTypeSpanner extends DateTimeType {

--- a/src/main/java/liquibase/ext/spanner/datatype/TinyIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TinyIntTypeSpanner.java
@@ -17,18 +17,19 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.TinyIntType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 public class TinyIntTypeSpanner extends TinyIntType {
   private static final DatabaseDataType INT64 = new DatabaseDataType("INT64");
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return INT64;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/TinyIntTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/TinyIntTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.TinyIntType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 public class TinyIntTypeSpanner extends TinyIntType {

--- a/src/main/java/liquibase/ext/spanner/datatype/UuidTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/UuidTypeSpanner.java
@@ -17,6 +17,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.UUIDType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** UUID is translated to STRING(36) as Cloud Spanner does not have a built-in type for UUID's. */
 public class UuidTypeSpanner extends UUIDType {
@@ -24,12 +25,12 @@ public class UuidTypeSpanner extends UUIDType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return UUID;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/datatype/UuidTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/UuidTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.UUIDType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** UUID is translated to STRING(36) as Cloud Spanner does not have a built-in type for UUID's. */

--- a/src/main/java/liquibase/ext/spanner/datatype/VarcharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/VarcharTypeSpanner.java
@@ -17,19 +17,24 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.VarcharType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** VARCHAR(n) is translated to STRING(n). */
 public class VarcharTypeSpanner extends VarcharType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
-      return new DatabaseDataType("STRING(" + getParameters()[0] + ")");
+    if (database instanceof ICloudSpanner) {
+      if (getParameters() != null && getParameters().length > 0) {
+        return new DatabaseDataType("STRING(" + getParameters()[0] + ")");
+      } else {
+        return new DatabaseDataType("STRING(MAX)");
+      }
     } else {
       return super.toDatabaseDataType(database);
     }

--- a/src/main/java/liquibase/ext/spanner/datatype/VarcharTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/VarcharTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.VarcharType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** VARCHAR(n) is translated to STRING(n). */

--- a/src/main/java/liquibase/ext/spanner/datatype/XmlTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/XmlTypeSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.datatype;
 import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.XMLType;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 
 /** XML is translated to STRING(MAX) as Cloud Spanner does not have a built-in type for XML. */

--- a/src/main/java/liquibase/ext/spanner/datatype/XmlTypeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/XmlTypeSpanner.java
@@ -17,6 +17,7 @@ import liquibase.database.Database;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.core.XMLType;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 
 /** XML is translated to STRING(MAX) as Cloud Spanner does not have a built-in type for XML. */
 public class XmlTypeSpanner extends XMLType {
@@ -24,12 +25,12 @@ public class XmlTypeSpanner extends XMLType {
 
   @Override
   public boolean supports(Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return XML;
     } else {
       return super.toDatabaseDataType(database);

--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/UniqueConstraintSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/UniqueConstraintSnapshotGeneratorSpanner.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
@@ -14,7 +13,6 @@ import liquibase.snapshot.jvm.UniqueConstraintSnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
-import java.util.logging.Logger;
 
 public class UniqueConstraintSnapshotGeneratorSpanner extends UniqueConstraintSnapshotGenerator
 {

--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/UniqueConstraintSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/UniqueConstraintSnapshotGeneratorSpanner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotGenerator;
@@ -26,7 +27,7 @@ public class UniqueConstraintSnapshotGeneratorSpanner extends UniqueConstraintSn
    */
   @Override
   public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
-    if (database instanceof CloudSpanner) {
+    if (database instanceof ICloudSpanner) {
       return PRIORITY_DATABASE;
     }
     return PRIORITY_NONE;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddColumnGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddColumnGeneratorSpanner.java
@@ -36,6 +36,10 @@ public class AddColumnGeneratorSpanner extends AddColumnGenerator {
 
     @Override
     protected String generateSingleColumnSQL(AddColumnStatement statement, Database database) {
+        // Create a proxy that will add the COLUMN keyword in front of the column name when it is
+        // needed specifically for this change. That prevents the Cloud Spanner emulator from
+        // rejecting the DDL statement, as it requires the COLUMN keyword to be included in the
+        // statement.
         InvocationHandler handler = (proxy, method, args) -> {
             if (method.getName().equals("escapeColumnName")) {
                 return "COLUMN " + method.invoke(database, args);

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddColumnGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddColumnGeneratorSpanner.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.core.AddColumnGenerator;
+import liquibase.statement.core.AddColumnStatement;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+public class AddColumnGeneratorSpanner extends AddColumnGenerator {
+
+    @Override
+    public int getPriority() {
+        return SqlGenerator.PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(AddColumnStatement statement, Database database) {
+        return (database instanceof ICloudSpanner);
+    }
+
+    @Override
+    protected String generateSingleColumnSQL(AddColumnStatement statement, Database database) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if (method.getName().equals("escapeColumnName")) {
+                return "COLUMN " + method.invoke(database, args);
+            }
+            return method.invoke(database, args);
+        };
+        ICloudSpanner databaseWithColumnKeyword = (ICloudSpanner) Proxy.newProxyInstance(ICloudSpanner.class.getClassLoader(),
+                new Class[] { ICloudSpanner.class },
+                handler);
+        return super.generateSingleColumnSQL(statement, databaseWithColumnKeyword);
+    }
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddDefaultValueGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddDefaultValueGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddDefaultValueGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddDefaultValueGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.AddDefaultValueGenerator;
@@ -40,6 +41,6 @@ public class AddDefaultValueGeneratorSpanner extends AddDefaultValueGenerator {
 
   @Override
   public boolean supports(AddDefaultValueStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddForeignKeyConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddForeignKeyConstraintGeneratorSpanner.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddForeignKeyConstraintGenerator;
+import liquibase.statement.core.AddForeignKeyConstraintStatement;
+
+public class AddForeignKeyConstraintGeneratorSpanner extends AddForeignKeyConstraintGenerator {
+
+    @Override
+    public int getPriority() {
+        return SqlGenerator.PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(AddForeignKeyConstraintStatement statement, Database database) {
+        return (database instanceof ICloudSpanner);
+    }
+
+    @Override
+    public Sql[] generateSql(AddForeignKeyConstraintStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        String onUpdate = statement.getOnUpdate();
+        String onDelete = statement.getOnDelete();
+        try {
+            statement.setOnUpdate(null);
+            statement.setOnDelete(null);
+            return super.generateSql(statement, database, sqlGeneratorChain);
+        } finally {
+            statement.setOnUpdate(onUpdate);
+            statement.setOnDelete(onDelete);
+        }
+    }
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddForeignKeyConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddForeignKeyConstraintGeneratorSpanner.java
@@ -38,6 +38,8 @@ public class AddForeignKeyConstraintGeneratorSpanner extends AddForeignKeyConstr
         String onUpdate = statement.getOnUpdate();
         String onDelete = statement.getOnDelete();
         try {
+            // Ignore any onUpdate or onDelete clauses. Ignoring this instead of failing is
+            // consistent with other databases that also do not support these features.
             statement.setOnUpdate(null);
             statement.setOnDelete(null);
             return super.generateSql(statement, database, sqlGeneratorChain);

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddPrimaryKeyGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddPrimaryKeyGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.AddPrimaryKeyGenerator;
@@ -42,6 +43,6 @@ public class AddPrimaryKeyGeneratorSpanner extends AddPrimaryKeyGenerator {
 
   @Override
   public boolean supports(AddPrimaryKeyStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddPrimaryKeyGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddPrimaryKeyGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddUniqueConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddUniqueConstraintGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.AddUniqueConstraintGenerator;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AddUniqueConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AddUniqueConstraintGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.AddUniqueConstraintGenerator;
 import liquibase.statement.core.AddUniqueConstraintStatement;
@@ -35,7 +36,7 @@ public class AddUniqueConstraintGeneratorSpanner extends AddUniqueConstraintGene
 
   @Override
   public boolean supports(AddUniqueConstraintStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -46,7 +47,7 @@ public class CreateDatabaseChangeLogTableGeneratorSpanner
 
   @Override
   public boolean supports(CreateDatabaseChangeLogTableStatement statement, Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateProcedureGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateProcedureGeneratorSpanner.java
@@ -17,6 +17,7 @@ import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -50,6 +51,6 @@ public class CreateProcedureGeneratorSpanner extends CreateProcedureGenerator {
 
   @Override
   public boolean supports(CreateProcedureStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateProcedureGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateProcedureGeneratorSpanner.java
@@ -16,7 +16,6 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGenerator;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateSequenceGenerator;
@@ -40,6 +41,6 @@ public class CreateSequenceGeneratorSpanner extends CreateSequenceGenerator {
 
   @Override
   public boolean supports(CreateSequenceStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
@@ -45,26 +45,30 @@ public class CreateTableGeneratorSpanner extends CreateTableGenerator {
   public Sql[] generateSql(
       CreateTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
     Sql[] res = super.generateSql(statement, database, sqlGeneratorChain);
-    // Move the PRIMARY KEY statement from inside the table creation to outside.
-    StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
-    buffer.append(
-        database.escapeColumnNameList(
-            StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
-    buffer.append(")");
+    if (statement.getPrimaryKeyConstraint() != null && statement.getPrimaryKeyConstraint().getColumns() != null) {
+      // Move the PRIMARY KEY statement from inside the table creation to outside.
+      StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
+      buffer.append(
+              database.escapeColumnNameList(
+                      StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+      buffer.append(")");
 
-    String pk = buffer.toString();
-    String sql = res[0].toSql();
-    sql = sql.replace(pk, "");
-    // Append PRIMARY KEY (without the leading ,)
-    sql = sql + pk.substring(1);
+      String pk = buffer.toString();
+      String sql = res[0].toSql();
+      sql = sql.replace(pk, "");
+      // Append PRIMARY KEY (without the leading ,)
+      sql = sql + pk.substring(1);
 
-    return new Sql[] {
-      new UnparsedSql(
-          sql,
-          res[0]
-              .getAffectedDatabaseObjects()
-              .toArray(new DatabaseObject[res[0].getAffectedDatabaseObjects().size()]))
-    };
+      return new Sql[]{
+              new UnparsedSql(
+                      sql,
+                      res[0]
+                              .getAffectedDatabaseObjects()
+                              .toArray(new DatabaseObject[res[0].getAffectedDatabaseObjects().size()]))
+      };
+    } else {
+      return res;
+    }
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
@@ -45,30 +45,31 @@ public class CreateTableGeneratorSpanner extends CreateTableGenerator {
   public Sql[] generateSql(
       CreateTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
     Sql[] res = super.generateSql(statement, database, sqlGeneratorChain);
-    if (statement.getPrimaryKeyConstraint() != null && statement.getPrimaryKeyConstraint().getColumns() != null) {
-      // Move the PRIMARY KEY statement from inside the table creation to outside.
-      StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
-      buffer.append(
-              database.escapeColumnNameList(
-                      StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
-      buffer.append(")");
-
-      String pk = buffer.toString();
-      String sql = res[0].toSql();
-      sql = sql.replace(pk, "");
-      // Append PRIMARY KEY (without the leading ,)
-      sql = sql + pk.substring(1);
-
-      return new Sql[]{
-              new UnparsedSql(
-                      sql,
-                      res[0]
-                              .getAffectedDatabaseObjects()
-                              .toArray(new DatabaseObject[res[0].getAffectedDatabaseObjects().size()]))
-      };
-    } else {
+    // If there is no PK constraint, leave it as it is and let validate method above throw the error.
+    if (statement.getPrimaryKeyConstraint() == null || statement.getPrimaryKeyConstraint().getColumns() == null) {
       return res;
     }
+    
+    // Move the PRIMARY KEY statement from inside the table creation to outside.
+    StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
+    buffer.append(
+            database.escapeColumnNameList(
+                    StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+    buffer.append(")");
+
+    String pk = buffer.toString();
+    String sql = res[0].toSql();
+    sql = sql.replace(pk, "");
+    // Append PRIMARY KEY (without the leading ,)
+    sql = sql + pk.substring(1);
+
+    return new Sql[]{
+            new UnparsedSql(
+                    sql,
+                    res[0]
+                            .getAffectedDatabaseObjects()
+                            .toArray(new DatabaseObject[res[0].getAffectedDatabaseObjects().size()]))
+    };
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateViewGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateViewGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateViewGenerator;
@@ -40,6 +41,6 @@ public class CreateViewGeneratorSpanner extends CreateViewGenerator {
 
   @Override
   public boolean supports(CreateViewStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropDefaultValueGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropDefaultValueGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropDefaultValueGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropDefaultValueGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropDefaultValueGenerator;
@@ -40,6 +41,6 @@ public class DropDefaultValueGeneratorSpanner extends DropDefaultValueGenerator 
 
   @Override
   public boolean supports(DropDefaultValueStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropPrimaryKeyGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropPrimaryKeyGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropPrimaryKeyGenerator;
@@ -42,6 +43,6 @@ public class DropPrimaryKeyGeneratorSpanner extends DropPrimaryKeyGenerator {
 
   @Override
   public boolean supports(DropPrimaryKeyStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropPrimaryKeyGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropPrimaryKeyGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropProcedureGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropProcedureGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropProcedureGenerator;
@@ -42,6 +43,6 @@ public class DropProcedureGeneratorSpanner extends DropProcedureGenerator {
 
   @Override
   public boolean supports(DropProcedureStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropProcedureGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropProcedureGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropSequenceGenerator;
@@ -40,6 +41,6 @@ public class DropSequenceGeneratorSpanner extends DropSequenceGenerator {
 
   @Override
   public boolean supports(DropSequenceStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropUniqueConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropUniqueConstraintGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropUniqueConstraintGenerator;
 import liquibase.statement.core.DropUniqueConstraintStatement;
@@ -35,7 +36,7 @@ public class DropUniqueConstraintGeneratorSpanner extends DropUniqueConstraintGe
 
   @Override
   public boolean supports(DropUniqueConstraintStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropUniqueConstraintGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropUniqueConstraintGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropUniqueConstraintGenerator;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropViewGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropViewGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.DropViewGenerator;
@@ -40,6 +41,6 @@ public class DropViewGeneratorSpanner extends DropViewGenerator {
 
   @Override
   public boolean supports(DropViewStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/InsertOrUpdateGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/InsertOrUpdateGeneratorSpanner.java
@@ -19,7 +19,6 @@ package liquibase.ext.spanner.sqlgenerator;
 import java.util.ArrayList;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/InsertOrUpdateGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/InsertOrUpdateGeneratorSpanner.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -29,7 +30,7 @@ import liquibase.statement.core.InsertOrUpdateStatement;
 public class InsertOrUpdateGeneratorSpanner extends InsertOrUpdateGenerator {
   @Override
   public boolean supports(InsertOrUpdateStatement statement, Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameColumnGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameColumnGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.RenameColumnGenerator;
@@ -40,6 +41,6 @@ public class RenameColumnGeneratorSpanner extends RenameColumnGenerator {
 
   @Override
   public boolean supports(RenameColumnStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameColumnGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameColumnGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameSequenceGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.RenameSequenceGenerator;
@@ -40,6 +41,6 @@ public class RenameSequenceGeneratorSpanner extends RenameSequenceGenerator {
 
   @Override
   public boolean supports(RenameSequenceStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameSequenceGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameTableGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.RenameTableGenerator;
@@ -40,6 +41,6 @@ public class RenameTableGeneratorSpanner extends RenameTableGenerator {
 
   @Override
   public boolean supports(RenameTableStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameTableGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameViewGeneratorSpanner.java
@@ -16,6 +16,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.RenameViewGenerator;
@@ -40,6 +41,6 @@ public class RenameViewGeneratorSpanner extends RenameViewGenerator {
 
   @Override
   public boolean supports(RenameViewStatement statement, Database database) {
-    return (database instanceof CloudSpanner);
+    return (database instanceof ICloudSpanner);
   }
 }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameViewGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/RenameViewGeneratorSpanner.java
@@ -15,7 +15,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/SetNullableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/SetNullableGeneratorSpanner.java
@@ -19,6 +19,7 @@ package liquibase.ext.spanner.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.ext.spanner.CloudSpanner;
+import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGenerator;
@@ -30,7 +31,7 @@ public class SetNullableGeneratorSpanner extends SetNullableGenerator {
 
   @Override
   public boolean supports(SetNullableStatement statement, Database database) {
-    return database instanceof CloudSpanner;
+    return database instanceof ICloudSpanner;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/SetNullableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/SetNullableGeneratorSpanner.java
@@ -18,7 +18,6 @@ package liquibase.ext.spanner.sqlgenerator;
 
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
-import liquibase.ext.spanner.CloudSpanner;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <logger name="io.grpc.netty.shaded" level="INFO" />
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,3 +1,0 @@
-<configuration>
-    <logger name="io.grpc.netty.shaded" level="INFO" /> 
-</configuration>

--- a/src/test/groovy/liquibase/ext/spanner/CloudSpannerHarnessTest.groovy
+++ b/src/test/groovy/liquibase/ext/spanner/CloudSpannerHarnessTest.groovy
@@ -1,0 +1,7 @@
+package liquibase.ext.spanner
+
+import liquibase.harness.BaseHarnessSuite
+
+class CloudSpannerHarnessTest extends BaseHarnessSuite {
+
+}

--- a/src/test/groovy/liquibase/ext/spanner/CloudSpannerHarnessTest.groovy
+++ b/src/test/groovy/liquibase/ext/spanner/CloudSpannerHarnessTest.groovy
@@ -3,5 +3,4 @@ package liquibase.ext.spanner
 import liquibase.harness.BaseHarnessSuite
 
 class CloudSpannerHarnessTest extends BaseHarnessSuite {
-
 }

--- a/src/test/java/liquibase/ext/spanner/AddColumnTest.java
+++ b/src/test/java/liquibase/ext/spanner/AddColumnTest.java
@@ -38,12 +38,12 @@ public class AddColumnTest extends AbstractMockServerTest {
     // The following statement does not include the COLUMN keyword. According to the Cloud Spanner
     // documentation the keyword is required, but the documentation is slightly off here. The COLUMN
     // keyword is actually optional in Cloud Spanner (as in most other DBMS's).
-    String expectedSql = "ALTER TABLE Singers ADD SingerInfo BYTES(MAX)";
+    String expectedSql = "ALTER TABLE Singers ADD COLUMN SingerInfo BYTES(MAX)";
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"add-singerinfo-to-singers-table.spanner.yaml"}) {
       try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+           Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"));
       }
     }
@@ -58,16 +58,16 @@ public class AddColumnTest extends AbstractMockServerTest {
   @Test
   void testAddTrackAndLyricsToSongsFromYaml() throws Exception {
     String[] expectedSql =
-        new String[] {
-          "ALTER TABLE Songs ADD Track INT64 NOT NULL", "ALTER TABLE Songs ADD Lyrics STRING(MAX)"
-        };
+            new String[]{
+                    "ALTER TABLE Songs ADD COLUMN Track INT64 NOT NULL", "ALTER TABLE Songs ADD COLUMN Lyrics STRING(MAX)"
+            };
     for (String sql : expectedSql) {
       addUpdateDdlStatementsResponse(sql);
     }
 
-    for (String file : new String[] {"add-track-and-lyrics-to-songs-table.spanner.yaml"}) {
+    for (String file : new String[]{"add-track-and-lyrics-to-songs-table.spanner.yaml"}) {
       try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+           Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"));
       }
     }
@@ -84,17 +84,17 @@ public class AddColumnTest extends AbstractMockServerTest {
   @Test
   void testAddSingerToConcertsFromYaml() throws Exception {
     String[] expectedSql =
-        new String[] {
-          "ALTER TABLE Concerts ADD SingerId INT64 NOT NULL",
-          "ALTER TABLE Concerts ADD CONSTRAINT FK_Concerts_Singer FOREIGN KEY (SingerId) REFERENCES Singers (SingerId)"
-        };
+            new String[]{
+                    "ALTER TABLE Concerts ADD COLUMN SingerId INT64 NOT NULL",
+                    "ALTER TABLE Concerts ADD CONSTRAINT FK_Concerts_Singer FOREIGN KEY (SingerId) REFERENCES Singers (SingerId)"
+            };
     for (String sql : expectedSql) {
       addUpdateDdlStatementsResponse(sql);
     }
 
-    for (String file : new String[] {"add-singer-to-concerts-table.spanner.yaml"}) {
+    for (String file : new String[]{"add-singer-to-concerts-table.spanner.yaml"}) {
       try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+           Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"));
       }
     }

--- a/src/test/java/liquibase/ext/spanner/MergeColumnsTest.java
+++ b/src/test/java/liquibase/ext/spanner/MergeColumnsTest.java
@@ -50,7 +50,7 @@ public class MergeColumnsTest extends AbstractMockServerTest {
   @Test
   void testMergeSingersFirstNamdAndLastNameFromYaml() throws Exception {
     String[] expectedSql = new String[] {
-        "ALTER TABLE Singers ADD FullName STRING(500)",
+        "ALTER TABLE Singers ADD COLUMN FullName STRING(500)",
         "ALTER TABLE Singers DROP COLUMN FirstName",
         "ALTER TABLE Singers DROP COLUMN LastName",
       };

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/AddDropDefaultValueTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/AddDropDefaultValueTest.java
@@ -24,8 +24,6 @@ import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.exception.ValidationFailedException;
 import liquibase.ext.spanner.AbstractMockServerTest;
-import liquibase.ext.spanner.sqlgenerator.AddDefaultValueGeneratorSpanner;
-import liquibase.ext.spanner.sqlgenerator.DropDefaultValueGeneratorSpanner;
 
 @Execution(ExecutionMode.SAME_THREAD)
 public class AddDropDefaultValueTest extends AbstractMockServerTest {

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/RenameTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/RenameTableTest.java
@@ -21,7 +21,6 @@ import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.exception.ValidationFailedException;
 import liquibase.ext.spanner.AbstractMockServerTest;
-import liquibase.ext.spanner.sqlgenerator.RenameTableGeneratorSpanner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+   spanner-emulator:
+     image: gcr.io/cloud-spanner-emulator/emulator:latest
+     ports:
+       - 9010:9010
+       - 9020:9020

--- a/src/test/resources/docker/init-cloudspanner.sql
+++ b/src/test/resources/docker/init-cloudspanner.sql
@@ -1,0 +1,39 @@
+
+-- To run Liquibase Harness test suite:
+-- 1. Start Cloud Spanner emulator with `docker run -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator`
+-- 2. Execute the script below to initialize a database on projects/my-project/instances/my-instance/databases/my-database
+-- 3. Execute test suite
+
+START BATCH DDL;
+CREATE TABLE authors (
+                         id   INT64 NOT NULL,
+                         first_name  STRING(1024),
+                         last_name   STRING(1024),
+                         email   STRING(1024),
+                         birthdate  DATE,
+                         added timestamp NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY(id);
+CREATE TABLE posts (
+                       id   INT64 NOT NULL,
+                       author_id  INT64 NOT NULL,
+                       title   STRING(1024),
+                       description   STRING(1024),
+                       content   STRING(1024),
+                       inserted_date  DATE
+) PRIMARY KEY(id);
+RUN BATCH;
+
+START BATCH DML;
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added) VALUES
+(1,'Eileen','Lubowitz','ppaucek@example.org','1991-03-04','2004-05-30 02:08:25'),
+(2,'Tamia','Mayert','shansen@example.org','2016-03-27','2014-03-21 02:52:00'),
+(3,'Cyril','Funk','reynolds.godfrey@example.com','1988-04-21','2011-06-24 18:17:48'),
+(4,'Nicolas','Buckridge','xhoeger@example.net','2017-02-03','2019-04-22 02:04:41'),
+(5,'Jayden','Walter','lillian66@example.com','2010-02-27','1990-02-04 02:32:00');
+INSERT INTO posts (id, author_id, title, description, content, inserted_date) VALUES
+(1,1,'temporibus','voluptatum','Fugit non et doloribus repudiandae.','2015-11-18'),
+(2,2,'ea','aut','Tempora molestias maiores provident molestiae sint possimus quasi.','1975-06-08'),
+(3,3,'illum','rerum','Delectus recusandae sit officiis dolor.','1975-02-25'),
+(4,4,'itaque','deleniti','Magni nam optio id recusandae.','2010-07-28'),
+(5,5,'ad','similique','Rerum tempore quis ut nesciunt qui excepturi est.','2006-10-09');
+RUN BATCH;

--- a/src/test/resources/docker/init-cloudspanner.sql
+++ b/src/test/resources/docker/init-cloudspanner.sql
@@ -1,8 +1,9 @@
 
 -- To run Liquibase Harness test suite:
 -- 1. Start Cloud Spanner emulator with `docker run -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator`
--- 2. Execute the script below to initialize a database on projects/my-project/instances/my-instance/databases/my-database
--- 3. Execute test suite
+-- 2. Create an instance and a database on the emulator (See https://cloud.google.com/spanner/docs/emulator#using_the_gcloud_cli_with_the_emulator).
+-- 3. Execute the script below to initialize a database on projects/my-project/instances/my-instance/databases/my-database
+-- 4. Execute test suite
 
 START BATCH DDL;
 CREATE TABLE authors (

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -2,8 +2,5 @@ inputFormat: xml
 context: testContext
 
 databasesUnderTest:
-  - name: postgresql
-    version: 13
-    url: jdbc:postgresql://localhost:5437/lbcat
-    username: lbuser
-    password: LiquibasePass1
+  - name: cloudspanner
+    url: jdbc:cloudspanner://localhost:9010/projects/test-project/instances/test-instance/databases/test-database

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -1,0 +1,9 @@
+inputFormat: xml
+context: testContext
+
+databasesUnderTest:
+  - name: postgresql
+    version: 13
+    url: jdbc:postgresql://localhost:5437/lbcat
+    username: lbuser
+    password: LiquibasePass1

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -3,4 +3,5 @@ context: testContext
 
 databasesUnderTest:
   - name: cloudspanner
-    url: jdbc:cloudspanner://localhost:9010/projects/test-project/instances/test-instance/databases/test-database
+    version: 1.0
+    url: jdbc:cloudspanner://localhost:9010/projects/my-project/instances/my-instance/databases/my-database?usePlainText=true

--- a/src/test/resources/liquibase.properties
+++ b/src/test/resources/liquibase.properties
@@ -1,0 +1,1 @@
+logLevel=warning

--- a/src/test/resources/liquibase.properties
+++ b/src/test/resources/liquibase.properties
@@ -1,1 +1,0 @@
-logLevel=warning

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/addColumn.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/addColumn.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="1" author="kristyl">
+        <addColumn tableName="authors">
+            <column name="varcharColumn" type="varchar"/>
+            <column name="intColumn" type="int"/>
+            <column name="dateColumn" type="date"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createTableDataTypeText.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createTableDataTypeText.xml
@@ -4,11 +4,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
-    <changeSet id="1" author="kristyl">
-        <addColumn tableName="authors">
-            <column name="varcharColumn" type="varchar"/>
-            <column name="intColumn" type="int"/>
-            <column name="dateColumn" type="date"/>
-        </addColumn>
+    <changeSet id="1" author="loite">
+        <createTable tableName="createTableDataTypeText">
+            <column name="id" type="int">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="textCol" type="text"/>
+        </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/sql.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/sql.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="sqlTest" author="kristyl">
+        <comment>Creates a table and inserts values into the table with actual SQL</comment>
+        <createTable tableName="sqltest">
+            <column name="id" type="int">
+                <constraints primaryKey="true" />
+            </column>
+        </createTable>
+        <sql>
+            start batch dml;
+            insert into sqltest (id) values (1);
+            insert into sqltest (id) values (2);
+            insert into sqltest (id) values (3);
+            run batch;
+        </sql>
+        <rollback>
+            <dropTable tableName="sqltest"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addColumn.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addColumn.sql
@@ -1,0 +1,3 @@
+ALTER TABLE authors ADD varcharColumn VARCHAR
+ALTER TABLE authors ADD intColumn INT
+ALTER TABLE authors ADD dateColumn date

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addColumn.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addColumn.sql
@@ -1,3 +1,6 @@
-ALTER TABLE authors ADD varcharColumn VARCHAR
-ALTER TABLE authors ADD intColumn INT
-ALTER TABLE authors ADD dateColumn date
+ALTER TABLE authors ADD COLUMN varcharColumn STRING(25)
+ALTER TABLE authors ADD COLUMN intColumn INT64
+ALTER TABLE authors ADD COLUMN dateColumn date
+UPDATE authors SET varcharColumn = 'INITIAL_VALUE' WHERE TRUE
+UPDATE authors SET intColumn = 5 WHERE TRUE
+UPDATE authors SET dateColumn = DATE '2020-09-21' WHERE TRUE

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addDefaultValue.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addDefaultValue.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support DEFAULT values

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addDefaultValueComputed.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addDefaultValueComputed.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support DEFAULT values

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addForeignKey.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES authors (id)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addNotNullConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addNotNullConstraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ALTER COLUMN inserted_date date NOT NULL

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addPrimaryKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addPrimaryKey.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support adding primary keys, because it does not support creating a table without a primary key

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addUniqueConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/addUniqueConstraint.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support unique constraints. Use unique index instead.

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createIndex.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_first_name ON authors(first_name)
+CREATE INDEX idx_last_name ON authors(last_name)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTable.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTable.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test_table (test_id INT64 NOT NULL, test_column STRING(50) NOT NULL) PRIMARY KEY (test_id)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTableDataTypeText.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTableDataTypeText.sql
@@ -1,0 +1,1 @@
+CREATE TABLE createTableDataTypeText (id INT64 NOT NULL, textCol STRING(MAX)) PRIMARY KEY (id)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createView.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createView.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support views

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropColumn.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropColumn.sql
@@ -1,0 +1,3 @@
+ALTER TABLE posts ADD COLUMN varcharColumn STRING(25)
+UPDATE posts SET varcharColumn = 'INITIAL_VALUE' WHERE TRUE
+ALTER TABLE posts DROP COLUMN varcharColumn

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropDefaultValue.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropDefaultValue.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support default values

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropForeignKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropForeignKey.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES authors (id)
+ALTER TABLE posts DROP CONSTRAINT fk_posts_authors_test

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropIndex.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_first_name ON authors(first_name)
+DROP INDEX idx_first_name

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropNotNullConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropNotNullConstraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts ALTER COLUMN inserted_date date NOT NULL
+ALTER TABLE posts ALTER COLUMN inserted_date date

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropPrimaryKey.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropPrimaryKey.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support dropping a primary key

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropTable.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropTable.sql
@@ -1,0 +1,2 @@
+CREATE TABLE test_table (test_id INT64 NOT NULL, test_column STRING(50) NOT NULL) PRIMARY KEY (test_id)
+DROP TABLE test_table

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropUniqueConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropUniqueConstraint.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support unique constraints. Use unique indexes instead.

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropView.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropView.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support views

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameColumn.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameColumn.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support renaming columns

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameTable.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameTable.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support renaming tables

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameView.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/renameView.sql
@@ -1,0 +1,1 @@
+INVALID TEST Cloud Spanner does not support views

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/sql.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/sql.sql
@@ -1,0 +1,6 @@
+CREATE TABLE sqltest (id INT64 NOT NULL) PRIMARY KEY (id)
+start batch dml
+insert into sqltest (id) values (1)
+insert into sqltest (id) values (2)
+insert into sqltest (id) values (3)
+run batch


### PR DESCRIPTION
Adds the standard Liquibase test harness suite tests to the Spanner Liquibase integration. The tests can be executed from the IDE (IntelliJ), and works both when the project has been imported as a Maven and as a Gradle project.

* All tests that cover features that are not supported by Cloud Spanner (e.g. views, dropping primary keys, ...) are skipped.
* Tests that use tables without primary keys in the default test suite are overridden by a Spanner specific version that does use a primary key.

All tests that cover features that are supported by Cloud Spanner succeed (on the emulator). For this, a couple of functional changes have been made to the Spanner Liquibase integration:
1. A Spanner-specific `AddColumnGenerator` has been added to ensure that the statement includes the `COLUMN` keyword (i.e. ALTER TABLE Foo ADD COLUMN Bar ...`). This is currently only required by the emulator, but as it is to be expected that many users will use the emulator to test their applications, it is important that the integration works as much as possible with the emulator.
2. A Spanner-specific `AddForeignKeyConstraintGenerator` has been added to ensure that any `OnUpdate` and `OnDelete` specifications are ignored, as this is not supported by Cloud Spanner. This is also in line with the Liquibase behavior for other databases that do not support these keywords.
3. An extra check was added to the `CreateTableGenerator` for Spanner. An array-out-of-bounds exception could be thrown if a table without primary keys was being generated. Now it throws an understandable exception, as Cloud Spanner does not support tables without a primary key.

This change also touches a large number of files as it adds the `ICloudSpanner` marker interface. Using a marker interface instead of a class for checking whether the database in use is Cloud Spanner is better, as it allows us to generate proxy objects when only one small feature of the default Liquibase implementation needs to be adjusted for a specific change. This strategy is applied to the new `AddColumnGenerator` to add the `COLUMN` keyword to the generated SQL.