### PR TITLE
fix: generateChangelog would generate wrong type names

### DIFF
--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -13,17 +13,32 @@
  */
 package liquibase.ext.spanner;
 
+import com.google.cloud.spanner.Type;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 
 public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner {
 
   public CloudSpanner() {
+    unmodifiableDataTypes.add(Type.Code.BOOL.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.DATE.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.FLOAT64.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.INT64.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.NUMERIC.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.STRUCT.name().toLowerCase());
+    unmodifiableDataTypes.add(Type.Code.TIMESTAMP.name().toLowerCase());
   }
 
   @Override
   public java.lang.Integer getDefaultPort() {
     return Integer.valueOf(9010);
+  }
+  
+  @Override
+  public boolean dataTypeIsNotModifiable(final String typeName) {
+    // All data types are returned including the length by the JDBC driver
+    // and are therefore unmodifiable.
+    return true;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/datatype/ArrayOfBytesSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ArrayOfBytesSpanner.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner.datatype;
+
+import liquibase.database.Database;
+import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
+import liquibase.datatype.core.UnknownType;
+import liquibase.ext.spanner.ICloudSpanner;
+
+/**
+ * ARRAY<BYTES(len)> needs special handling because it contains a length parameter that is not at
+ * the end of the type definition.
+ */
+@DataTypeInfo(name = "array<bytes>", aliases = {"java.sql.Types.ARRAY", "java.lang.String[]"},
+    minParameters = 1, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DATABASE)
+public class ArrayOfBytesSpanner extends UnknownType {
+  public ArrayOfBytesSpanner() {
+    super("ARRAY<BYTES>", 1, 1);
+  }
+
+  @Override
+  public boolean supports(Database database) {
+    return database instanceof ICloudSpanner;
+  }
+
+  @Override
+  public DatabaseDataType toDatabaseDataType(Database database) {
+    Object[] parameters = getParameters();
+    if (parameters != null && parameters.length == 1) {
+      return new DatabaseDataType(String.format("ARRAY<BYTES(%s)>", parameters[0]));
+    }
+    return super.toDatabaseDataType(database);
+  }
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/datatype/ArrayOfStringSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/datatype/ArrayOfStringSpanner.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner.datatype;
+
+import liquibase.database.Database;
+import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
+import liquibase.datatype.core.UnknownType;
+import liquibase.ext.spanner.ICloudSpanner;
+
+/**
+ * ARRAY<STRING(len)> needs special handling because it contains a length parameter that is not at
+ * the end of the type definition.
+ */
+@DataTypeInfo(name = "array<string>", aliases = {"java.sql.Types.ARRAY", "java.lang.String[]"},
+    minParameters = 1, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DATABASE)
+public class ArrayOfStringSpanner extends UnknownType {
+  public ArrayOfStringSpanner() {
+    super("ARRAY<STRING>", 1, 1);
+  }
+
+  @Override
+  public boolean supports(Database database) {
+    return database instanceof ICloudSpanner;
+  }
+
+  @Override
+  public DatabaseDataType toDatabaseDataType(Database database) {
+    Object[] parameters = getParameters();
+    if (parameters != null && parameters.length == 1) {
+      return new DatabaseDataType(String.format("ARRAY<STRING(%s)>", parameters[0]));
+    }
+    return super.toDatabaseDataType(database);
+  }
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+}

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -17,11 +17,13 @@
 package com.google.spanner.liquibase;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,6 +33,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
@@ -40,6 +49,9 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import liquibase.CatalogAndSchema;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
@@ -48,6 +60,7 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
+import liquibase.integration.commandline.Main;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
@@ -480,19 +493,19 @@ public class LiquibaseTests {
 
   @Test
   void doEmulatorSpannerCreateAllDataTypesTest()
-      throws SQLException, LiquibaseException {
+      throws Exception {
     doSpannerCreateAllDataTypesTest(getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
   void doRealSpannerCreateAllDataTypesTest()
-      throws SQLException, LiquibaseException {
+      throws Exception {
      doSpannerCreateAllDataTypesTest(getSpannerReal());
   }
   
   private void doSpannerCreateAllDataTypesTest(TestHarness.Connection testHarness)
-      throws SQLException, LiquibaseException {
+      throws Exception {
 
     // No columns yet in the table -- it doesn't exist
     testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes");
@@ -526,7 +539,17 @@ public class LiquibaseTests {
         new ColDesc("ColTime", "TIMESTAMP"),
         new ColDesc("ColTinyInt", "INT64"),
         new ColDesc("ColUUID", "STRING(36)"),
-        new ColDesc("ColXml", "STRING(MAX)")
+        new ColDesc("ColXml", "STRING(MAX)"),
+        new ColDesc("ColBoolArray", "ARRAY<BOOL>"),
+        new ColDesc("ColBytesArray", "ARRAY<BYTES(100)>"),
+        new ColDesc("ColBytesMaxArray", "ARRAY<BYTES(MAX)>"),
+        new ColDesc("ColDateArray", "ARRAY<DATE>"),
+        new ColDesc("ColFloat64Array", "ARRAY<FLOAT64>"),
+        new ColDesc("ColInt64Array", "ARRAY<INT64>"),
+        new ColDesc("ColNumericArray", "ARRAY<NUMERIC>"),
+        new ColDesc("ColStringArray", "ARRAY<STRING(100)>"),
+        new ColDesc("ColStringMaxArray", "ARRAY<STRING(MAX)>"),
+        new ColDesc("ColTimestampArray", "ARRAY<TIMESTAMP>")
     };
     testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes", cols);
 
@@ -542,6 +565,20 @@ public class LiquibaseTests {
     testSnapshotTableAndColumns(snapshot, "TableWithAllLiquibaseTypes", cols);
     testSnapshotPrimaryKey(snapshot, "TableWithAllLiquibaseTypes",
         new ColDesc("ColBigInt", "INT64", Boolean.FALSE));
+    
+    // Generate an initial changelog for the database.
+    File changeLogFile = File.createTempFile("test-changelog", ".xml");
+    changeLogFile.deleteOnExit();
+    Main.run(new String[] {
+        "--overwriteOutputFile=true",
+        String.format("--changeLogFile=%s", changeLogFile.getAbsolutePath()),
+        String.format("--url=%s", testHarness.getJDBCConnection().getMetaData().getURL()),
+        "generateChangeLog"});
+    DocumentBuilderFactory documentBuilderFactory =
+        DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+    Document document = builder.parse(changeLogFile);
+    testTableColumnsInXml(document, "TableWithAllLiquibaseTypes", cols);
 
     // Do rollback
     liquibase.rollback(1, null);
@@ -582,21 +619,41 @@ public class LiquibaseTests {
 
     Assert.assertEquals(rows.size(), cols.length);
     for (int i = 0; i < cols.length; i++) {
-      Assert.assertEquals(
-          rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name),
-          0);
+      assertEquals(cols[i].name, rows.get(i).get("COLUMN_NAME"));
       if (cols[i].type != null) {
-        Assert.assertEquals(
-            rows.get(i).get("TYPE_NAME").toString().compareToIgnoreCase(cols[i].type),
-            0);
+        assertEquals(cols[i].type, rows.get(i).get("TYPE_NAME"));
       }
       if (cols[i].isNullable != null) {
         String expectedValue = cols[i].isNullable ? "YES" : "NO";
-        Assert.assertEquals(
-            rows.get(i).get("IS_NULLABLE").toString().compareToIgnoreCase(expectedValue),
-            0);
+        assertEquals(expectedValue, rows.get(i).get("IS_NULLABLE"));
       }
     }
+  }
+
+  static void testTableColumnsInXml(Document document, String table, ColDesc... cols)
+      throws XPathExpressionException {
+    XPathFactory xPathfactory = XPathFactory.newInstance();
+    XPath xpath = xPathfactory.newXPath();
+    XPathExpression expr = xpath.compile(String.format("//createTable[@tableName=\"%s\"]", table));
+    NodeList createTables = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+    assertEquals(1, createTables.getLength());
+    Node createTable = createTables.item(0);
+
+    for (ColDesc col : cols) {
+      testTableColumn(xpath, createTable, col);
+    }
+  }
+
+  static void testTableColumn(XPath xpath, Node createTableNode, ColDesc col)
+      throws XPathExpressionException {
+    NodeList createCols =
+        (NodeList) xpath.compile(String.format("//column[@name=\"%s\"]", col.name))
+            .evaluate(createTableNode, XPathConstants.NODESET);
+    assertEquals(1, createCols.getLength());
+    Node createCol = createCols.item(0);
+    assertEquals(col.name, createCol.getAttributes().getNamedItem("name").getNodeValue());
+    assertEquals(col.type.toUpperCase(),
+        createCol.getAttributes().getNamedItem("type").getNodeValue().toUpperCase());
   }
 
   static void testTablePrimaryKeys(java.sql.Connection conn, String table, ColDesc... cols)

--- a/src/test/java/liquibase/ext/spanner/CreateTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/CreateTableTest.java
@@ -77,7 +77,7 @@ public class CreateTableTest extends AbstractMockServerTest {
   @Test
   void testCreateTableWithAllLiquibaseTypesFromYaml() throws Exception {
     String expectedSql =
-        "CREATE TABLE TableWithAllLiquibaseTypes (ColBigInt INT64 NOT NULL, ColBlob BYTES(MAX), ColBoolean BOOL, ColChar STRING(100), ColNChar STRING(50), ColNVarchar STRING(100), ColVarchar STRING(200), ColClob STRING(MAX), ColDateTime TIMESTAMP, ColTimestamp timestamp, ColDate date, ColDecimal NUMERIC, ColDouble FLOAT64, ColFloat FLOAT64, ColInt INT64, ColMediumInt INT64, ColNumber NUMERIC, ColSmallInt INT64, ColTime TIMESTAMP, ColTinyInt INT64, ColUUID STRING(36), ColXml STRING(MAX)) PRIMARY KEY (ColBigInt)";
+        "CREATE TABLE TableWithAllLiquibaseTypes (ColBigInt INT64 NOT NULL, ColBlob BYTES(MAX), ColBoolean BOOL, ColChar STRING(100), ColNChar STRING(50), ColNVarchar STRING(100), ColVarchar STRING(200), ColClob STRING(MAX), ColDateTime TIMESTAMP, ColTimestamp timestamp, ColDate date, ColDecimal NUMERIC, ColDouble FLOAT64, ColFloat FLOAT64, ColInt INT64, ColMediumInt INT64, ColNumber NUMERIC, ColSmallInt INT64, ColTime TIMESTAMP, ColTinyInt INT64, ColUUID STRING(36), ColXml STRING(MAX), ColBoolArray ARRAY<BOOL>, ColBytesArray ARRAY<BYTES(100)>, ColBytesMaxArray ARRAY<BYTES(MAX)>, ColDateArray ARRAY<DATE>, ColFloat64Array ARRAY<FLOAT64>, ColInt64Array ARRAY<INT64>, ColNumericArray ARRAY<NUMERIC>, ColStringArray ARRAY<STRING(100)>, ColStringMaxArray ARRAY<STRING(MAX)>, ColTimestampArray ARRAY<TIMESTAMP>) PRIMARY KEY (ColBigInt)";
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"create-table-with-all-liquibase-types.spanner.yaml"}) {

--- a/src/test/java/liquibase/ext/spanner/GenerateSnapshotTest.java
+++ b/src/test/java/liquibase/ext/spanner/GenerateSnapshotTest.java
@@ -13,9 +13,9 @@
  */
 package liquibase.ext.spanner;
 
-import com.google.cloud.spanner.Statement;
 import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
 import com.google.common.collect.ImmutableList;
 import java.sql.Connection;
 import java.util.Set;
@@ -148,8 +148,11 @@ public class GenerateSnapshotTest extends AbstractMockServerTest {
       assertThat(singers.getName()).isEqualTo("Singers");
       assertThat(singers.getColumns()).hasSize(3);
       assertThat(singers.getColumn("SingerId").getType().getTypeName()).isEqualTo("INT64");
+      assertThat(singers.getColumn("SingerId").getType().toString()).isEqualTo("INT64");
       assertThat(singers.getColumn("FirstName").getType().getTypeName()).isEqualTo("STRING(100)");
+      assertThat(singers.getColumn("FirstName").getType().toString()).isEqualTo("STRING(100)");
       assertThat(singers.getColumn("LastName").getType().getTypeName()).isEqualTo("STRING(200)");
+      assertThat(singers.getColumn("LastName").getType().toString()).isEqualTo("STRING(200)");
     }
   }
 }

--- a/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
+++ b/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
@@ -94,3 +94,33 @@ databaseChangeLog:
             -  column:
                 name:    ColXml
                 type:    XML
+            -  column:
+                name:    ColBoolArray
+                type:    ARRAY<BOOL>
+            -  column:
+                name:    ColBytesArray
+                type:    ARRAY<BYTES(100)>
+            -  column:
+                name:    ColBytesMaxArray
+                type:    ARRAY<BYTES(MAX)>
+            -  column:
+                name:    ColDateArray
+                type:    ARRAY<DATE>
+            -  column:
+                name:    ColFloat64Array
+                type:    ARRAY<FLOAT64>
+            -  column:
+                name:    ColInt64Array
+                type:    ARRAY<INT64>
+            -  column:
+                name:    ColNumericArray
+                type:    ARRAY<NUMERIC>
+            -  column:
+                name:    ColStringArray
+                type:    ARRAY<STRING(100)>
+            -  column:
+                name:    ColStringMaxArray
+                type:    ARRAY<STRING(MAX)>
+            -  column:
+                name:    ColTimestampArray
+                type:    ARRAY<TIMESTAMP>


### PR DESCRIPTION
Generating a change log from an existing database would generate wrong type names in some cases:
- `INT64` (and others) would be generated as `INT64(19)` because Liquibase assumed that the type could have variable length.
- `ARRAY<STRING(len)>` and `ARRAY<BYTES(len)>` types would be generated with the length moved to the end of the type declaration (e.g. `ARRAY<STRING>(100)`), as Liquibase assumes that all data types that have a parameter will have the parameter at the end.

Fixes #75, #76 and #77 

cc @marcindyjas