### PR TITLE
fix: remove logback config from build

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,3 +1,0 @@
-<configuration>
-    <logger name="io.grpc.netty.shaded" level="INFO" />
-</configuration>


### PR DESCRIPTION
The Spanner Liquibase extension should not include a `logback.xml` configuration file in the default build.

Updates #74 