### PR TITLE
fix: support nullable primary key columns

### DIFF
--- a/src/main/java/liquibase/ext/spanner/change/CreateTableChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/CreateTableChangeSpanner.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner.change;
+
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.change.core.CreateTableChange;
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.ext.spanner.sqlgenerator.CreateTableStatementSpanner;
+
+/** Custom implementation for Cloud Spanner that enables the creation of nullable primary key columns. */
+@DatabaseChange(name="createTable", description = "Create Table", priority = ChangeMetaData.PRIORITY_DATABASE)
+public class CreateTableChangeSpanner extends CreateTableChange {
+
+  @Override
+  public boolean supports(Database database) {
+    return (database instanceof ICloudSpanner);
+  }
+  
+  protected CreateTableStatementSpanner generateCreateTableStatement() {
+    return new CreateTableStatementSpanner(getCatalogName(), getSchemaName(), getTableName(), getRemarks());
+  }
+
+}

--- a/src/main/java/liquibase/ext/spanner/change/CreateTableChangeSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/change/CreateTableChangeSpanner.java
@@ -29,6 +29,7 @@ public class CreateTableChangeSpanner extends CreateTableChange {
     return (database instanceof ICloudSpanner);
   }
   
+  @Override
   protected CreateTableStatementSpanner generateCreateTableStatement() {
     return new CreateTableStatementSpanner(getCatalogName(), getSchemaName(), getTableName(), getRemarks());
   }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.datatype.LiquibaseDataType;
+import liquibase.statement.ColumnConstraint;
+import liquibase.statement.NotNullConstraint;
+import liquibase.statement.core.CreateTableStatement;
+
+/**
+ * Liquibase always adds a {@link NotNullConstraint} for all primary key columns, although Cloud
+ * Spanner does support nullable columns in the primary key. This {@link CreateTableStatement}
+ * overrides that behavior by removing the automatically added {@link NotNullConstraint} again from
+ * the primary key columns that are added.
+ */
+public class CreateTableStatementSpanner extends CreateTableStatement {
+
+  public CreateTableStatementSpanner(String catalogName, String schemaName, String tableName, String remarks) {
+    super(catalogName, schemaName, tableName, remarks);
+  }
+  
+  public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue, String keyName,
+      String tablespace, ColumnConstraint... constraints) {
+    CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, keyName, tablespace, constraints);
+    if (!containsNotNullConstraintForColumn(columnName, constraints)) {
+      getNotNullColumns().remove(columnName);
+    }
+    return statement;
+  }
+  
+  public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
+      Boolean validate,String keyName, String tablespace, ColumnConstraint... constraints) {
+    CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, keyName, tablespace, constraints);
+    if (!containsNotNullConstraintForColumn(columnName, constraints)) {
+      getNotNullColumns().remove(columnName);
+    }
+    return statement;
+  }
+  
+  private boolean containsNotNullConstraintForColumn(String column, ColumnConstraint... constraints) {
+    for (ColumnConstraint constraint : constraints) {
+      if (constraint instanceof NotNullConstraint) {
+        NotNullConstraint nn = (NotNullConstraint) constraint;
+        if (column.equals(nn.getColumnName())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
@@ -43,7 +43,7 @@ public class CreateTableStatementSpanner extends CreateTableStatement {
   @Override
   public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
       Boolean validate,String keyName, String tablespace, ColumnConstraint... constraints) {
-    CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, keyName, tablespace, constraints);
+    CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, validate, keyName, tablespace, constraints);
     if (!containsNotNullConstraintForColumn(columnName, constraints)) {
       getNotNullColumns().remove(columnName);
     }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
@@ -30,6 +30,7 @@ public class CreateTableStatementSpanner extends CreateTableStatement {
     super(catalogName, schemaName, tableName, remarks);
   }
   
+  @Override
   public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue, String keyName,
       String tablespace, ColumnConstraint... constraints) {
     CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, keyName, tablespace, constraints);
@@ -39,6 +40,7 @@ public class CreateTableStatementSpanner extends CreateTableStatement {
     return statement;
   }
   
+  @Override
   public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
       Boolean validate,String keyName, String tablespace, ColumnConstraint... constraints) {
     CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, keyName, tablespace, constraints);

--- a/src/test/java/liquibase/ext/spanner/CreateMultipleTablesTest.java
+++ b/src/test/java/liquibase/ext/spanner/CreateMultipleTablesTest.java
@@ -27,23 +27,20 @@ public class CreateMultipleTablesTest extends AbstractMockServerTest {
   @Test
   void testCreateMultipleTablesFromYaml() throws Exception {
     String createSingers =
-        "CREATE TABLE Singers (SingerId INT64 NOT NULL, FirstName STRING(255), LastName STRING(255) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)";
+        "CREATE TABLE Singers (SingerId INT64, FirstName STRING(255), LastName STRING(255) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)";
     String createAlbums =
-        "CREATE TABLE Albums (AlbumId INT64 NOT NULL, Title STRING(255), Singer INT64) PRIMARY KEY (AlbumId)";
+        "CREATE TABLE Albums (AlbumId INT64, Title STRING(255), Singer INT64) PRIMARY KEY (AlbumId)";
     addUpdateDdlStatementsResponse(Arrays.asList(createSingers, createAlbums));
 
     for (String file : new String[] {"create-multiple-tables.spanner.yaml"}) {
-      try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
         // Update to version v0.1.
         liquibase.update(new Contexts("test"), new LabelExpression("version 0.1"));
 
         // Register result for tagging the last update and then tag it.
-        mockSpanner.putStatementResult(
-            StatementResult.update(
-                Statement.of(
-                    "UPDATE DATABASECHANGELOG SET TAG = 'rollback-v0.1' WHERE DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM DATABASECHANGELOG)"),
-                1L));
+        mockSpanner.putStatementResult(StatementResult.update(Statement.of(
+            "UPDATE DATABASECHANGELOG SET TAG = 'rollback-v0.1' WHERE DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM DATABASECHANGELOG)"),
+            1L));
         liquibase.tag("rollback-v0.1");
       }
     }

--- a/src/test/java/liquibase/ext/spanner/CreateTableTest.java
+++ b/src/test/java/liquibase/ext/spanner/CreateTableTest.java
@@ -28,21 +28,18 @@ public class CreateTableTest extends AbstractMockServerTest {
   @Test
   void testCreateSingersTableFromYaml() throws Exception {
     String expectedSql =
-        "CREATE TABLE Singers (SingerId INT64 NOT NULL, FirstName STRING(255), LastName STRING(255) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)";
+        "CREATE TABLE Singers (SingerId INT64, FirstName STRING(255), LastName STRING(255) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)";
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"create-singers-table.spanner.yaml"}) {
-      try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
         // Update to version v0.1.
         liquibase.update(new Contexts("test"), new LabelExpression("version 0.1"));
 
         // Register result for tagging the last update and then tag it.
-        mockSpanner.putStatementResult(
-            StatementResult.update(
-                Statement.of(
-                    "UPDATE DATABASECHANGELOG SET TAG = 'rollback-v0.1' WHERE DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM DATABASECHANGELOG)"),
-                1L));
+        mockSpanner.putStatementResult(StatementResult.update(Statement.of(
+            "UPDATE DATABASECHANGELOG SET TAG = 'rollback-v0.1' WHERE DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM DATABASECHANGELOG)"),
+            1L));
         liquibase.tag("rollback-v0.1");
       }
     }
@@ -61,8 +58,7 @@ public class CreateTableTest extends AbstractMockServerTest {
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"create-table-with-all-spanner-types.spanner.yaml"}) {
-      try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"), new LabelExpression("version 0.2"));
       }
     }
@@ -81,8 +77,7 @@ public class CreateTableTest extends AbstractMockServerTest {
     addUpdateDdlStatementsResponse(expectedSql);
 
     for (String file : new String[] {"create-table-with-all-liquibase-types.spanner.yaml"}) {
-      try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"), new LabelExpression("version 0.3"));
       }
     }
@@ -97,8 +92,7 @@ public class CreateTableTest extends AbstractMockServerTest {
   @Test
   void testTableWithoutPrimaryKeyFromYaml() throws Exception {
     for (String file : new String[] {"create-table-without-pk.spanner.yaml"}) {
-      try (Connection con = createConnection();
-          Liquibase liquibase = getLiquibase(con, file)) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
         liquibase.update(new Contexts("test"), new LabelExpression("version 0.1"));
         fail("missing expected validation exception");
       } catch (ValidationFailedException e) {

--- a/src/test/resources/create-singers-table.spanner.yaml
+++ b/src/test/resources/create-singers-table.spanner.yaml
@@ -32,6 +32,7 @@ databaseChangeLog:
                 type:    BIGINT
                 constraints:
                   primaryKey: true
+                  nullable: true
             -  column:
                 remarks: Singer's first name
                 name:    FirstName

--- a/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
+++ b/src/test/resources/create-table-with-all-liquibase-types.spanner.yaml
@@ -31,6 +31,7 @@ databaseChangeLog:
                 type:    BIGINT
                 constraints:
                   primaryKey: true
+                  nullable: false
             -  column:
                 name:    ColBlob
                 type:    BLOB

--- a/src/test/resources/create-table-with-all-spanner-types.spanner.yaml
+++ b/src/test/resources/create-table-with-all-spanner-types.spanner.yaml
@@ -31,6 +31,7 @@ databaseChangeLog:
                 type:    BIGINT
                 constraints:
                   primaryKey: true
+                  nullable: false
             -  column:
                 name:    ColFloat64
                 type:    DOUBLE

--- a/src/test/resources/create_table.spanner.yaml
+++ b/src/test/resources/create_table.spanner.yaml
@@ -31,6 +31,7 @@ databaseChangeLog:
                 type:  int64
                 constraints:
                   primaryKey: true
+                  nullable: false
             -  column:  
                 name:  name  
                 type:  varchar(255)  


### PR DESCRIPTION
Liquibase automatically adds a NotNullConstraint to all primary key columns, regardless whether these have been marked as nullable or not. Cloud Spanner supports nullable primary key columns. This change adds a custom CreateTable change and statement for Spanner that removes the automatically generated NotNullConstraint from primary key columns.

NotNullConstraints that are explicitly set on primary key columns are respected.

Fixes #83