### PR TITLE
deps: update to jdbc driver version 2.0 and set user agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ jar {
 // Liquibase 4 uses ServiceLoader
 serviceLoader {
     serviceInterface 'liquibase.database.Database'
+    serviceInterface 'liquibase.database.DatabaseConnection'
     serviceInterface 'liquibase.datatype.LiquibaseDataType'
     serviceInterface 'liquibase.sqlgenerator.SqlGenerator'
     serviceInterface 'liquibase.change.Change'
@@ -66,7 +67,7 @@ serviceLoader {
 dependencies {
 
     // Cloud Spanner related
-    implementation platform('com.google.cloud:libraries-bom:16.4.0')
+    implementation platform('com.google.cloud:libraries-bom:20.0.0')
     implementation("com.google.cloud:google-cloud-spanner-jdbc")
 
     // Liquibase Core - needed for testing and docker container

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>16.4.0</version>
+        <version>20.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -259,6 +259,7 @@
         <configuration>
           <services>
             <param>liquibase.database.Database</param>
+            <param>liquibase.database.DatabaseConnection</param>
             <param>liquibase.datatype.LiquibaseDataType</param>
             <param>liquibase.sqlgenerator.SqlGenerator</param>
             <param>liquibase.change.Change</param>

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -14,8 +14,12 @@
 package liquibase.ext.spanner;
 
 import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
+import liquibase.database.jvm.JdbcConnection;
 
 public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner {
 
@@ -78,6 +82,41 @@ public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner 
       return "com.google.cloud.spanner.jdbc.JdbcDriver";
     }
     return null;
+  }
+  
+  @Override
+  public void setConnection(final DatabaseConnection conn) {
+    DatabaseConnection connectionToUse = conn;
+    // If a user creates a JDBC connection manually and then passes this manually into Liquibase,
+    // then this method will be called by Liquibase. Normally, a connection will be opened by
+    // Liquibase based on the connection URL that is configured. In that case, the
+    // CloudSpanneConnection class will ensure that the correct user-agent string is set. That is
+    // not the case when a user creates the connection manually. This method therefore checks
+    // whether it is actually a Spanner JDBC connection, and if it is, replaces it with a new
+    // connection that uses the same connection URL + the user-agent string. The original connection
+    // is kept open in case the caller also uses the connection for other purposes, but will
+    // automatically be closed when the 'replacement' connection is closed. The latter should be
+    // safe, even if the caller uses the connection for other purposes, as even if the connection
+    // was not replaced it would have been closed by Liquibase at the same moment.
+    if (!(conn instanceof CloudSpannerConnection) && conn instanceof JdbcConnection
+        && ((JdbcConnection) conn)
+            .getUnderlyingConnection() instanceof CloudSpannerJdbcConnection) {
+      // The underlying connection is a Spanner JDBC connection. Check whether it already included a
+      // user-agent string.
+      if (!conn.getURL().contains("userAgent=")) {
+        // The underlying connection does not use a specific user-agent string. Create a replacement
+        // connection that will be used by Liquibase with the correct user-agent.
+        try {
+          connectionToUse = new CloudSpannerConnection(
+              DriverManager.getConnection(conn.getURL() + ";userAgent=sp-liq"), conn);
+        } catch (SQLException e) {
+          // Ignore and use the original connection. This could for example happen if the user is
+          // using an older version of the Spanner JDBC driver that does not support this user-agent
+          // string.
+        }
+      }
+    }
+    super.setConnection(connectionToUse);
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -90,14 +90,16 @@ public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner 
     // If a user creates a JDBC connection manually and then passes this manually into Liquibase,
     // then this method will be called by Liquibase. Normally, a connection will be opened by
     // Liquibase based on the connection URL that is configured. In that case, the
-    // CloudSpanneConnection class will ensure that the correct user-agent string is set. That is
-    // not the case when a user creates the connection manually. This method therefore checks
-    // whether it is actually a Spanner JDBC connection, and if it is, replaces it with a new
-    // connection that uses the same connection URL + the user-agent string. The original connection
-    // is kept open in case the caller also uses the connection for other purposes, but will
-    // automatically be closed when the 'replacement' connection is closed. The latter should be
-    // safe, even if the caller uses the connection for other purposes, as even if the connection
-    // was not replaced it would have been closed by Liquibase at the same moment.
+    // CloudSpannerConnection class will ensure that the correct user-agent string is set. That is
+    // not the case when a user creates the connection programmatically and passes it in to
+    // Liquibase. This method therefore checks whether it is actually a Spanner JDBC connection,
+    // and if it is, replaces it with a new connection that uses the same connection URL + the
+    // user-agent string. The original connection is kept open in case the caller also uses the
+    // connection for other purposes, but will automatically be closed when the 'replacement'
+    // connection is closed.
+    // The latter should be safe, even if the caller uses the connection for other purposes, as
+    // even if the connection was not replaced it would have been closed by Liquibase at the same
+    // moment.
     if (!(conn instanceof CloudSpannerConnection) && conn instanceof JdbcConnection
         && ((JdbcConnection) conn)
             .getUnderlyingConnection() instanceof CloudSpannerJdbcConnection) {

--- a/src/main/java/liquibase/ext/spanner/CloudSpannerConnection.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpannerConnection.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner;
+
+import com.google.cloud.spanner.jdbc.JdbcDriver;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.util.Properties;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.servicelocator.LiquibaseService;
+
+@LiquibaseService()
+public class CloudSpannerConnection extends JdbcConnection {
+  private final DatabaseConnection originalConnection;
+
+  public CloudSpannerConnection() {
+    this.originalConnection = null;
+  }
+
+  public CloudSpannerConnection(Connection connection) {
+    super(connection);
+    this.originalConnection = null;
+  }
+
+  CloudSpannerConnection(Connection connection, DatabaseConnection originalConnection) {
+    super(connection);
+    this.originalConnection = originalConnection;
+  }
+
+  public int getPriority() {
+    // Using PRIORITY_DATABASE here does not work, as Liquibase core contains ProJdbcConnection that
+    // already has that priority.
+    return Integer.MAX_VALUE;
+  }
+
+  @Override
+  public void close() throws DatabaseException {
+    // Also close the original connection that this connection replaced.
+    if (originalConnection != null && !originalConnection.isClosed()) {
+      originalConnection.close();
+    }
+    super.close();
+  }
+
+  @Override
+  public void open(String url, Driver driverObject, Properties driverProperties)
+      throws DatabaseException {
+    // This method is called by Liquibase when a new connection is needed. The connection URL is
+    // part of the configuration that a user specifies for Liquibase. We append a user-agent string
+    // to the connection URL so we can track the usage of Liquibase.
+    if (url.startsWith("jdbc:cloudspanner") && !url.contains("userAgent=")) {
+      if (driverObject instanceof JdbcDriver) {
+        JdbcDriver driver = (JdbcDriver) driverObject;
+        // Only version 2 and higher support the Liquibase user-agent string.
+        // Earlier versions do support Liquibase, but will just use the default
+        // user-agent string.
+        if (driver.getMajorVersion() >= 2) {
+          url = url + ";userAgent=sp-liq";
+        }
+      }
+    }
+    super.open(url, driverObject, driverProperties);
+  }
+
+}

--- a/src/main/java/liquibase/ext/spanner/CloudSpannerConnection.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpannerConnection.java
@@ -23,9 +23,7 @@ import java.util.Properties;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
-import liquibase.servicelocator.LiquibaseService;
 
-@LiquibaseService()
 public class CloudSpannerConnection extends JdbcConnection {
   private final DatabaseConnection originalConnection;
 

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableGeneratorSpanner.java
@@ -21,7 +21,6 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateTableGenerator;
 import liquibase.statement.core.CreateTableStatement;
 import liquibase.structure.DatabaseObject;
-import org.apache.commons.lang3.StringUtils;
 
 public class CreateTableGeneratorSpanner extends CreateTableGenerator {
 
@@ -54,7 +53,7 @@ public class CreateTableGeneratorSpanner extends CreateTableGenerator {
     StringBuilder buffer = new StringBuilder(", PRIMARY KEY (");
     buffer.append(
             database.escapeColumnNameList(
-                    StringUtils.join(statement.getPrimaryKeyConstraint().getColumns(), ", ")));
+                    String.join(", ", statement.getPrimaryKeyConstraint().getColumns())));
     buffer.append(")");
 
     String pk = buffer.toString();

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -1,17 +1,15 @@
 /*
  * Copyright 2020 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.spanner.liquibase;
@@ -25,6 +23,7 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
 import java.io.File;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -110,14 +109,10 @@ public class LiquibaseTests {
 
   // Get the Liquibase changeset for the given log file and JDBC
   Liquibase getLiquibase(TestHarness.Connection testHarness, String changeLogFile)
-      throws DatabaseException {
-    Liquibase liquibase =
-        new Liquibase(
-            changeLogFile,
-            new ClassLoaderResourceAccessor(),
-            DatabaseFactory.getInstance()
-                .findCorrectDatabaseImplementation(
-                    new JdbcConnection(testHarness.getJDBCConnection())));
+      throws DatabaseException, SQLException {
+    Liquibase liquibase = new Liquibase(changeLogFile, new ClassLoaderResourceAccessor(),
+        DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+            new JdbcConnection(DriverManager.getConnection(testHarness.getConnectionUrl()))));
 
     return liquibase;
   }
@@ -135,29 +130,30 @@ public class LiquibaseTests {
 
   void doSanityCheckTest(TestHarness.Connection liquibaseTestHarness) throws SQLException {
 
-    // Execute Query
-    List<Map<String, Object>> rss = testQuery(liquibaseTestHarness.getJDBCConnection(), "SELECT 3");
+    try (Connection connection =
+        DriverManager.getConnection(liquibaseTestHarness.getConnectionUrl())) {
+      // Execute Query
+      List<Map<String, Object>> rss = testQuery(connection, "SELECT 3");
 
-    // Validate results
-    Assert.assertTrue(rss.size() == 1);
-    Assert.assertTrue(rss.get(0).get("1").equals("3"));
+      // Validate results
+      Assert.assertTrue(rss.size() == 1);
+      Assert.assertTrue(rss.get(0).get("1").equals("3"));
 
-    // Ensure SELECT COUNT(*) FROM DATABASECHANGELOGLOCK works
-    rss =
-        testQuery(
-            liquibaseTestHarness.getJDBCConnection(), "SELECT COUNT(*) FROM DATABASECHANGELOGLOCK");
+      // Ensure SELECT COUNT(*) FROM DATABASECHANGELOGLOCK works
+      rss = testQuery(connection, "SELECT COUNT(*) FROM DATABASECHANGELOGLOCK");
 
-    Assert.assertTrue("DATABASECHANGELOGLOCK does not exist", rss.size() == 1);
+      Assert.assertTrue("DATABASECHANGELOGLOCK does not exist", rss.size() == 1);
+    }
   }
 
   @Test
-  void doSpannerUpdateEmulatorTest() throws SQLException, LiquibaseException {
+  void doSpannerUpdateEmulatorTest() throws Exception {
     doLiquibaseUpdateTest(getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
-  void doSpannerUpdateRealTest() throws SQLException, LiquibaseException {
+  void doSpannerUpdateRealTest() throws Exception {
     doLiquibaseUpdateTest(getSpannerReal());
   }
 
@@ -174,37 +170,42 @@ public class LiquibaseTests {
   }
 
   void doDropAllForeignKeysTest(TestHarness.Connection testHarness) throws Exception {
-    Connection con = testHarness.getJDBCConnection();
-    try (Statement statement = con.createStatement()) {
-      statement.execute("START BATCH DDL");
-      statement.execute("CREATE TABLE Countries (Code STRING(10), Name STRING(100)) PRIMARY KEY (Code)");
-      statement.execute("CREATE TABLE Singers (SingerId INT64, Name STRING(100), Country STRING(100), CONSTRAINT FK_Singers_Countries FOREIGN KEY (Country) REFERENCES Countries (Code)) PRIMARY KEY (SingerId)");
-      statement.execute("RUN BATCH");
-      
-      try (ResultSet rs = statement.executeQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='FK_Singers_Countries'")) {
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getLong(1)).isEqualTo(1L);
-        assertThat(rs.next()).isFalse();
-      }
-      
-      try {
-        Liquibase liquibase = getLiquibase(testHarness, "drop-all-foreign-key-constraints-singers.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        
-        try (ResultSet rs = statement.executeQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='FK_Singers_Countries'")) {
+    try (Connection con = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = con.createStatement()) {
+        statement.execute("START BATCH DDL");
+        statement.execute(
+            "CREATE TABLE Countries (Code STRING(10), Name STRING(100)) PRIMARY KEY (Code)");
+        statement.execute(
+            "CREATE TABLE Singers (SingerId INT64, Name STRING(100), Country STRING(100), CONSTRAINT FK_Singers_Countries FOREIGN KEY (Country) REFERENCES Countries (Code)) PRIMARY KEY (SingerId)");
+        statement.execute("RUN BATCH");
+
+        try (ResultSet rs = statement.executeQuery(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='FK_Singers_Countries'")) {
           assertThat(rs.next()).isTrue();
-          assertThat(rs.getLong(1)).isEqualTo(0L);
+          assertThat(rs.getLong(1)).isEqualTo(1L);
           assertThat(rs.next()).isFalse();
         }
-      } finally {
-        statement.execute("START BATCH DDL");
-        statement.execute("DROP TABLE Singers");
-        statement.execute("DROP TABLE Countries");
-        statement.execute("RUN BATCH");
+
+        try (Liquibase liquibase =
+            getLiquibase(testHarness, "drop-all-foreign-key-constraints-singers.spanner.yaml")) {
+          liquibase.update(new Contexts("test"));
+
+          try (ResultSet rs = statement.executeQuery(
+              "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME='FK_Singers_Countries'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getLong(1)).isEqualTo(0L);
+            assertThat(rs.next()).isFalse();
+          }
+        } finally {
+          statement.execute("START BATCH DDL");
+          statement.execute("DROP TABLE Singers");
+          statement.execute("DROP TABLE Countries");
+          statement.execute("RUN BATCH");
+        }
       }
     }
   }
-  
+
   @Disabled("The emulator erroneously requires the optional COLUMN keyword to be included in ALTER TABLE <table> ADD [COLUMN] ...")
   @Test
   void doEmulatorMergeColumnsTest() throws Exception {
@@ -218,45 +219,47 @@ public class LiquibaseTests {
   }
 
   void doMergeColumnsTest(TestHarness.Connection testHarness) throws Exception {
-    Connection con = testHarness.getJDBCConnection();
-    try (Statement statement = con.createStatement()) {
-      statement.execute("START BATCH DDL");
-      statement.execute("CREATE TABLE Singers (SingerId INT64, FirstName STRING(100), LastName STRING(100)) PRIMARY KEY (SingerId)");
-      statement.execute("RUN BATCH");
-      
-      Object[][] singers = new Object[][] {
-        {1L, "FirstName1", "LastName1"},
-        {2L, "FirstName2", "LastName2"},
-        {3L, "FirstName3", "LastName3"},
-      };
-      statement.execute("BEGIN");
-      try (PreparedStatement ps = con.prepareStatement("INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (?, ?, ?)")) {
-        for (Object[] singer : singers) {
-          for (int p = 0; p < singer.length; p++) {
-            // JDBC param index is 1-based.
-            ps.setObject(p+1, singer[p]);
-          }
-          ps.addBatch();
-        }
-        ps.executeBatch();
-      }
-      statement.execute("COMMIT");
-      
-      try {
-        Liquibase liquibase = getLiquibase(testHarness, "merge-singers-firstname-and-lastname.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        
-        try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
-          for (int i=1; i<=singers.length; i++) {
-            assertThat(rs.next()).isTrue();
-            assertThat(rs.getString("FullName")).isEqualTo(String.format("FirstName%dsome-stringLastName%d", i, i));
-          }
-          assertThat(rs.next()).isFalse();
-        }
-      } finally {
+    try (Connection con = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = con.createStatement()) {
         statement.execute("START BATCH DDL");
-        statement.execute("DROP TABLE Singers");
+        statement.execute(
+            "CREATE TABLE Singers (SingerId INT64, FirstName STRING(100), LastName STRING(100)) PRIMARY KEY (SingerId)");
         statement.execute("RUN BATCH");
+
+        Object[][] singers = new Object[][] {{1L, "FirstName1", "LastName1"},
+            {2L, "FirstName2", "LastName2"}, {3L, "FirstName3", "LastName3"},};
+        statement.execute("BEGIN");
+        try (PreparedStatement ps = con.prepareStatement(
+            "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (?, ?, ?)")) {
+          for (Object[] singer : singers) {
+            for (int p = 0; p < singer.length; p++) {
+              // JDBC param index is 1-based.
+              ps.setObject(p + 1, singer[p]);
+            }
+            ps.addBatch();
+          }
+          ps.executeBatch();
+        }
+        statement.execute("COMMIT");
+
+        try {
+          Liquibase liquibase =
+              getLiquibase(testHarness, "merge-singers-firstname-and-lastname.spanner.yaml");
+          liquibase.update(new Contexts("test"));
+
+          try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
+            for (int i = 1; i <= singers.length; i++) {
+              assertThat(rs.next()).isTrue();
+              assertThat(rs.getString("FullName"))
+                  .isEqualTo(String.format("FirstName%dsome-stringLastName%d", i, i));
+            }
+            assertThat(rs.next()).isFalse();
+          }
+        } finally {
+          statement.execute("START BATCH DDL");
+          statement.execute("DROP TABLE Singers");
+          statement.execute("RUN BATCH");
+        }
       }
     }
   }
@@ -273,48 +276,56 @@ public class LiquibaseTests {
   }
 
   void doModifyDataTypeTest(TestHarness.Connection testHarness) throws Exception {
-    Connection con = testHarness.getJDBCConnection();
-    try (Statement statement = con.createStatement()) {
-      statement.execute("START BATCH DDL");
-      statement.execute("CREATE TABLE Singers (SingerId INT64, LastName STRING(100) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)");
-      statement.execute("RUN BATCH");
-      
-      try (ResultSet rs = statement.executeQuery("SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='LastName'")) {
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getString(1)).isEqualTo("STRING(100)");
-        assertThat(rs.getString(2)).isEqualTo("NO");
-        assertThat(rs.next()).isFalse();
-      }
-      try (ResultSet rs = statement.executeQuery("SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='SingerInfo'")) {
-        assertThat(rs.next()).isTrue();
-        assertThat(rs.getString(1)).isEqualTo("BYTES(MAX)");
-        assertThat(rs.getString(2)).isEqualTo("YES");
-        assertThat(rs.next()).isFalse();
-      }
-      
-      try {
-        Liquibase liquibase = getLiquibase(testHarness, "modify-data-type-singers-lastname.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        
-        try (ResultSet rs = statement.executeQuery("SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='LastName'")) {
+    try (Connection con = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = con.createStatement()) {
+        statement.execute("START BATCH DDL");
+        statement.execute(
+            "CREATE TABLE Singers (SingerId INT64, LastName STRING(100) NOT NULL, SingerInfo BYTES(MAX)) PRIMARY KEY (SingerId)");
+        statement.execute("RUN BATCH");
+
+        try (ResultSet rs = statement.executeQuery(
+            "SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='LastName'")) {
           assertThat(rs.next()).isTrue();
-          assertThat(rs.getString(1)).isEqualTo("STRING(1000)");
+          assertThat(rs.getString(1)).isEqualTo("STRING(100)");
           assertThat(rs.getString(2)).isEqualTo("NO");
           assertThat(rs.next()).isFalse();
         }
-        
-        liquibase = getLiquibase(testHarness, "modify-data-type-singers-singerinfo.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        try (ResultSet rs = statement.executeQuery("SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='SingerInfo'")) {
+        try (ResultSet rs = statement.executeQuery(
+            "SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='SingerInfo'")) {
           assertThat(rs.next()).isTrue();
-          assertThat(rs.getString(1)).isEqualTo("STRING(MAX)");
+          assertThat(rs.getString(1)).isEqualTo("BYTES(MAX)");
           assertThat(rs.getString(2)).isEqualTo("YES");
           assertThat(rs.next()).isFalse();
         }
-      } finally {
-        statement.execute("START BATCH DDL");
-        statement.execute("DROP TABLE Singers");
-        statement.execute("RUN BATCH");
+
+        try (Liquibase liquibase =
+            getLiquibase(testHarness, "modify-data-type-singers-lastname.spanner.yaml")) {
+          liquibase.update(new Contexts("test"));
+
+          try (ResultSet rs = statement.executeQuery(
+              "SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='LastName'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString(1)).isEqualTo("STRING(1000)");
+            assertThat(rs.getString(2)).isEqualTo("NO");
+            assertThat(rs.next()).isFalse();
+          }
+        }
+
+        try (Liquibase liquibase =
+            getLiquibase(testHarness, "modify-data-type-singers-singerinfo.spanner.yaml")) {
+          liquibase.update(new Contexts("test"));
+          try (ResultSet rs = statement.executeQuery(
+              "SELECT SPANNER_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='Singers' AND COLUMN_NAME='SingerInfo'")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString(1)).isEqualTo("STRING(MAX)");
+            assertThat(rs.getString(2)).isEqualTo("YES");
+            assertThat(rs.next()).isFalse();
+          }
+        } finally {
+          statement.execute("START BATCH DDL");
+          statement.execute("DROP TABLE Singers");
+          statement.execute("RUN BATCH");
+        }
       }
     }
   }
@@ -331,40 +342,36 @@ public class LiquibaseTests {
   }
 
   void doLoadDataTest(TestHarness.Connection testHarness) throws Exception {
-    Connection con = testHarness.getJDBCConnection();
-    try (Statement statement = con.createStatement()) {
-      statement.execute("START BATCH DDL");
-      statement.execute("CREATE TABLE Singers ("
-          + "SingerId INT64,"
-          + "Name STRING(100),"
-          + "Description STRING(MAX),"
-          + "SingerInfo BYTES(MAX),"
-          + "AnyGood BOOL,"
-          + "Birthdate DATE,"
-          + "LastConcertTimestamp TIMESTAMP,"
-          + "ExternalID STRING(36),"
-          + ") PRIMARY KEY (SingerId)");
-      statement.execute("RUN BATCH");
-      try {
-        Liquibase liquibase = getLiquibase(testHarness, "load-data-singers.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        
-        try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
-          int index = 0;
-          while (rs.next()) {
-            index++;
-            assertThat(rs.getLong("SingerId")).isEqualTo(index);
-            assertThat(rs.getString("Name")).isEqualTo("Name " + index);
-            assertThat(rs.getString("Description")).isEqualTo("This is a CLOB description " + index);
-            assertThat(rs.getBytes("SingerInfo")).isEqualTo(ByteArray.copyFrom("singerinfo " + index).toByteArray());
-            assertThat(rs.getBoolean("AnyGood")).isEqualTo(index %2 == 0);
-          }
-          assertThat(index).isEqualTo(3);
-        }
-      } finally {
+    try (Connection con = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = con.createStatement()) {
         statement.execute("START BATCH DDL");
-        statement.execute("DROP TABLE Singers");
+        statement.execute("CREATE TABLE Singers (" + "SingerId INT64," + "Name STRING(100),"
+            + "Description STRING(MAX)," + "SingerInfo BYTES(MAX)," + "AnyGood BOOL,"
+            + "Birthdate DATE," + "LastConcertTimestamp TIMESTAMP," + "ExternalID STRING(36),"
+            + ") PRIMARY KEY (SingerId)");
         statement.execute("RUN BATCH");
+        try (Liquibase liquibase = getLiquibase(testHarness, "load-data-singers.spanner.yaml")) {
+          liquibase.update(new Contexts("test"));
+
+          try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
+            int index = 0;
+            while (rs.next()) {
+              index++;
+              assertThat(rs.getLong("SingerId")).isEqualTo(index);
+              assertThat(rs.getString("Name")).isEqualTo("Name " + index);
+              assertThat(rs.getString("Description"))
+                  .isEqualTo("This is a CLOB description " + index);
+              assertThat(rs.getBytes("SingerInfo"))
+                  .isEqualTo(ByteArray.copyFrom("singerinfo " + index).toByteArray());
+              assertThat(rs.getBoolean("AnyGood")).isEqualTo(index % 2 == 0);
+            }
+            assertThat(index).isEqualTo(3);
+          }
+        } finally {
+          statement.execute("START BATCH DDL");
+          statement.execute("DROP TABLE Singers");
+          statement.execute("RUN BATCH");
+        }
       }
     }
   }
@@ -381,263 +388,241 @@ public class LiquibaseTests {
   }
 
   void doLoadUpdateDataTest(TestHarness.Connection testHarness) throws Exception {
-    Connection con = testHarness.getJDBCConnection();
-    try (Statement statement = con.createStatement()) {
-      statement.execute("START BATCH DDL");
-      statement.execute("CREATE TABLE Singers ("
-          + "SingerId INT64,"
-          + "Name STRING(100),"
-          + "Description STRING(MAX),"
-          + "SingerInfo BYTES(MAX),"
-          + "AnyGood BOOL,"
-          + "Birthdate DATE,"
-          + "LastConcertTimestamp TIMESTAMP,"
-          + "ExternalID STRING(36),"
-          + ") PRIMARY KEY (SingerId)");
-      statement.execute("RUN BATCH");
-      // Insert one record that will be updated by Liquibase.
-      CloudSpannerJdbcConnection cs = con.unwrap(CloudSpannerJdbcConnection.class);
-      boolean wasAutoCommit = cs.getAutoCommit();
-      cs.setAutoCommit(true);
-      cs.write(Mutation.newInsertBuilder("Singers")
-          .set("SingerId").to(2L)
-          .set("Name").to("Some initial name")
-          .set("Description").to("Some initial description")
-          .set("SingerInfo").to(ByteArray.copyFrom("Some initial singer info"))
-          .set("AnyGood").to(false)
-          .set("Birthdate").to(Date.fromYearMonthDay(2000, 1, 1))
-          .set("LastConcertTimestamp").to(Timestamp.ofTimeMicroseconds(12345678))
-          .set("ExternalId").to("some initial external id")
-          .build());
-      cs.setAutoCommit(wasAutoCommit);
-      try {
-        Liquibase liquibase = getLiquibase(testHarness, "load-update-data-singers.spanner.yaml");
-        liquibase.update(new Contexts("test"));
-        
-        try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
-          int index = 0;
-          while (rs.next()) {
-            index++;
-            assertThat(rs.getLong("SingerId")).isEqualTo(index);
-            assertThat(rs.getString("Name")).isEqualTo("Name " + index);
-            assertThat(rs.getString("Description")).isEqualTo("Description " + index);
-            assertThat(rs.getBytes("SingerInfo")).isNull();
-            assertThat(rs.getBoolean("AnyGood")).isEqualTo(index % 2 == 0);
-          }
-          assertThat(index).isEqualTo(3);
-        }
-      } finally {
+    try (Connection con = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = con.createStatement()) {
         statement.execute("START BATCH DDL");
-        statement.execute("DROP TABLE Singers");
+        statement.execute("CREATE TABLE Singers (" + "SingerId INT64," + "Name STRING(100),"
+            + "Description STRING(MAX)," + "SingerInfo BYTES(MAX)," + "AnyGood BOOL,"
+            + "Birthdate DATE," + "LastConcertTimestamp TIMESTAMP," + "ExternalID STRING(36),"
+            + ") PRIMARY KEY (SingerId)");
         statement.execute("RUN BATCH");
+        // Insert one record that will be updated by Liquibase.
+        CloudSpannerJdbcConnection cs = con.unwrap(CloudSpannerJdbcConnection.class);
+        boolean wasAutoCommit = cs.getAutoCommit();
+        cs.setAutoCommit(true);
+        cs.write(Mutation.newInsertBuilder("Singers").set("SingerId").to(2L).set("Name")
+            .to("Some initial name").set("Description").to("Some initial description")
+            .set("SingerInfo").to(ByteArray.copyFrom("Some initial singer info")).set("AnyGood")
+            .to(false).set("Birthdate").to(Date.fromYearMonthDay(2000, 1, 1))
+            .set("LastConcertTimestamp").to(Timestamp.ofTimeMicroseconds(12345678))
+            .set("ExternalId").to("some initial external id").build());
+        cs.setAutoCommit(wasAutoCommit);
+        try (Liquibase liquibase =
+            getLiquibase(testHarness, "load-update-data-singers.spanner.yaml")) {
+          liquibase.update(new Contexts("test"));
+
+          try (ResultSet rs = statement.executeQuery("SELECT * FROM Singers ORDER BY SingerId")) {
+            int index = 0;
+            while (rs.next()) {
+              index++;
+              assertThat(rs.getLong("SingerId")).isEqualTo(index);
+              assertThat(rs.getString("Name")).isEqualTo("Name " + index);
+              assertThat(rs.getString("Description")).isEqualTo("Description " + index);
+              assertThat(rs.getBytes("SingerInfo")).isNull();
+              assertThat(rs.getBoolean("AnyGood")).isEqualTo(index % 2 == 0);
+            }
+            assertThat(index).isEqualTo(3);
+          }
+        } finally {
+          statement.execute("START BATCH DDL");
+          statement.execute("DROP TABLE Singers");
+          statement.execute("RUN BATCH");
+        }
       }
     }
   }
 
-  void doLiquibaseUpdateTest(TestHarness.Connection testHarness)
-      throws SQLException, LiquibaseException {
-    Liquibase liquibase = getLiquibase(testHarness, "changelog.spanner.sql");
+  void doLiquibaseUpdateTest(TestHarness.Connection testHarness) throws Exception {
+    try (Liquibase liquibase = getLiquibase(testHarness, "changelog.spanner.sql")) {
+      liquibase.update(null, new LabelExpression("base"));
+      liquibase.tag("mytag");
 
-    liquibase.update(null, new LabelExpression("base"));
-    liquibase.tag("mytag");
+      Connection currentConnection =
+          ((JdbcConnection) liquibase.getDatabase().getConnection()).getUnderlyingConnection();
+      List<Map<String, Object>> rss =
+          testQuery(currentConnection, "SELECT id, name, extra FROM table1");
+      Assert.assertTrue(rss.size() == 1);
+      Assert.assertTrue(rss.get(0).get("id").equals("1"));
+      Assert.assertTrue(rss.get(0).get("name").equals("test"));
+      Assert.assertTrue(rss.get(0).get("extra").equals("abc"));
 
-    List<Map<String, Object>> rss =
-        testQuery(testHarness.getJDBCConnection(), "SELECT id, name, extra FROM table1");
-    Assert.assertTrue(rss.size() == 1);
-    Assert.assertTrue(rss.get(0).get("id").equals("1"));
-    Assert.assertTrue(rss.get(0).get("name").equals("test"));
-    Assert.assertTrue(rss.get(0).get("extra").equals("abc"));
-
-    rss = testQuery(testHarness.getJDBCConnection(), "SELECT COUNT(*) FROM DATABASECHANGELOG");
-    Assert.assertTrue(rss.size() == 1);
-    Assert.assertTrue(rss.get(0).get("1").equals("3"));
+      rss = testQuery(currentConnection, "SELECT COUNT(*) FROM DATABASECHANGELOG");
+      Assert.assertTrue(rss.size() == 1);
+      Assert.assertTrue(rss.get(0).get("1").equals("3"));
+    }
   }
 
   @Test
-  void doEmulatorSpannerCreateAndRollbackTest() throws SQLException, LiquibaseException {
+  void doEmulatorSpannerCreateAndRollbackTest() throws Exception {
     doLiquibaseCreateAndRollbackTest("create_table.spanner.sql", getSpannerEmulator());
     doLiquibaseCreateAndRollbackTest("create_table.spanner.yaml", getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
-  void doRealSpannerCreateAndRollbackTest() throws SQLException, LiquibaseException {
+  void doRealSpannerCreateAndRollbackTest() throws Exception {
     doLiquibaseCreateAndRollbackTest("create_table.spanner.sql", getSpannerReal());
     doLiquibaseCreateAndRollbackTest("create_table.spanner.yaml", getSpannerReal());
   }
 
   void doLiquibaseCreateAndRollbackTest(String changeLogFile, TestHarness.Connection testHarness)
-      throws SQLException, LiquibaseException {
+      throws Exception {
+    try (Connection connection = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      testTableColumns(connection, "rollback_table");
+    }
 
-    testTableColumns(testHarness.getJDBCConnection(), "rollback_table");
+    try (Liquibase liquibase = getLiquibase(testHarness, changeLogFile)) {
+      liquibase.update(null, new LabelExpression("rollback_stuff"));
+      liquibase.tag("tag-at-rollback");
 
+      Connection currentConnection =
+          ((JdbcConnection) liquibase.getDatabase().getConnection()).getUnderlyingConnection();
+      testTableColumns(currentConnection, "rollback_table",
+          new ColDesc("id", "INT64", Boolean.FALSE), new ColDesc("name", "STRING(255)"));
 
-    Liquibase liquibase = getLiquibase(testHarness, changeLogFile);
-    liquibase.update(null, new LabelExpression("rollback_stuff"));
-    liquibase.tag("tag-at-rollback");
+      testTablePrimaryKeys(currentConnection, "rollback_table", new ColDesc("id"));
 
-    testTableColumns(testHarness.getJDBCConnection(), "rollback_table",
-        new ColDesc("id", "INT64", Boolean.FALSE),
-        new ColDesc("name", "STRING(255)")
-    );
+      // Do rollback
+      liquibase.rollback(1, null);
 
-    testTablePrimaryKeys(testHarness.getJDBCConnection(), "rollback_table",
-        new ColDesc("id"));
-
-    // Do rollback
-    liquibase.rollback(1, null);
-
-    // Ensure nothing is there!
-    testTableColumns(testHarness.getJDBCConnection(), "rollback_table");
+      // Ensure nothing is there!
+      testTableColumns(currentConnection, "rollback_table");
+    }
   }
 
   @Test
-  void doEmulatorSpannerCreateAllDataTypesTest()
-      throws Exception {
+  void doEmulatorSpannerCreateAllDataTypesTest() throws Exception {
     doSpannerCreateAllDataTypesTest(getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
-  void doRealSpannerCreateAllDataTypesTest()
-      throws Exception {
-     doSpannerCreateAllDataTypesTest(getSpannerReal());
+  void doRealSpannerCreateAllDataTypesTest() throws Exception {
+    doSpannerCreateAllDataTypesTest(getSpannerReal());
   }
-  
+
   private void doSpannerCreateAllDataTypesTest(TestHarness.Connection testHarness)
       throws Exception {
-
-    // No columns yet in the table -- it doesn't exist
-    testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes");
+    try (Connection connection = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      // No columns yet in the table -- it doesn't exist
+      testTableColumns(connection, "TableWithAllLiquibaseTypes");
+    }
 
     // Run the Liquibase with all types
-    Liquibase liquibase = getLiquibase(testHarness,
-        "create-table-with-all-liquibase-types.spanner.yaml");
-    liquibase.update(null, new LabelExpression("version 0.3"));
-    liquibase.tag("tag-at-rollback_all_types");
+    try (Liquibase liquibase =
+        getLiquibase(testHarness, "create-table-with-all-liquibase-types.spanner.yaml")) {
+      liquibase.update(null, new LabelExpression("version 0.3"));
+      liquibase.tag("tag-at-rollback_all_types");
 
-    // Expect all of the columns and types
-    ColDesc[] cols = new ColDesc[] {
-        new ColDesc("ColBigInt", "INT64", Boolean.FALSE),
-        new ColDesc("ColBlob", "BYTES(MAX)"),
-        new ColDesc("ColBoolean", "BOOL"),
-        new ColDesc("ColChar", "STRING(100)"),
-        new ColDesc("ColNChar", "STRING(50)"),
-        new ColDesc("ColNVarchar", "STRING(100)"),
-        new ColDesc("ColVarchar", "STRING(200)"),
-        new ColDesc("ColClob", "STRING(MAX)"),
-        new ColDesc("ColDateTime", "TIMESTAMP"),
-        new ColDesc("ColTimestamp", "TIMESTAMP"),
-        new ColDesc("ColDate", "DATE"),
-        new ColDesc("ColDecimal", "NUMERIC"),
-        new ColDesc("ColDouble", "FLOAT64"),
-        new ColDesc("ColFloat", "FLOAT64"),
-        new ColDesc("ColInt", "INT64"),
-        new ColDesc("ColMediumInt", "INT64"),
-        new ColDesc("ColNumber", "NUMERIC"),
-        new ColDesc("ColSmallInt", "INT64"),
-        new ColDesc("ColTime", "TIMESTAMP"),
-        new ColDesc("ColTinyInt", "INT64"),
-        new ColDesc("ColUUID", "STRING(36)"),
-        new ColDesc("ColXml", "STRING(MAX)"),
-        new ColDesc("ColBoolArray", "ARRAY<BOOL>"),
-        new ColDesc("ColBytesArray", "ARRAY<BYTES(100)>"),
-        new ColDesc("ColBytesMaxArray", "ARRAY<BYTES(MAX)>"),
-        new ColDesc("ColDateArray", "ARRAY<DATE>"),
-        new ColDesc("ColFloat64Array", "ARRAY<FLOAT64>"),
-        new ColDesc("ColInt64Array", "ARRAY<INT64>"),
-        new ColDesc("ColNumericArray", "ARRAY<NUMERIC>"),
-        new ColDesc("ColStringArray", "ARRAY<STRING(100)>"),
-        new ColDesc("ColStringMaxArray", "ARRAY<STRING(MAX)>"),
-        new ColDesc("ColTimestampArray", "ARRAY<TIMESTAMP>")
-    };
-    testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes", cols);
+      Connection currentConnection =
+          ((JdbcConnection) liquibase.getDatabase().getConnection()).getUnderlyingConnection();
+      // Expect all of the columns and types
+      ColDesc[] cols = new ColDesc[] {new ColDesc("ColBigInt", "INT64", Boolean.FALSE),
+          new ColDesc("ColBlob", "BYTES(MAX)"), new ColDesc("ColBoolean", "BOOL"),
+          new ColDesc("ColChar", "STRING(100)"), new ColDesc("ColNChar", "STRING(50)"),
+          new ColDesc("ColNVarchar", "STRING(100)"), new ColDesc("ColVarchar", "STRING(200)"),
+          new ColDesc("ColClob", "STRING(MAX)"), new ColDesc("ColDateTime", "TIMESTAMP"),
+          new ColDesc("ColTimestamp", "TIMESTAMP"), new ColDesc("ColDate", "DATE"),
+          new ColDesc("ColDecimal", "NUMERIC"), new ColDesc("ColDouble", "FLOAT64"),
+          new ColDesc("ColFloat", "FLOAT64"), new ColDesc("ColInt", "INT64"),
+          new ColDesc("ColMediumInt", "INT64"), new ColDesc("ColNumber", "NUMERIC"),
+          new ColDesc("ColSmallInt", "INT64"), new ColDesc("ColTime", "TIMESTAMP"),
+          new ColDesc("ColTinyInt", "INT64"), new ColDesc("ColUUID", "STRING(36)"),
+          new ColDesc("ColXml", "STRING(MAX)"), new ColDesc("ColBoolArray", "ARRAY<BOOL>"),
+          new ColDesc("ColBytesArray", "ARRAY<BYTES(100)>"),
+          new ColDesc("ColBytesMaxArray", "ARRAY<BYTES(MAX)>"),
+          new ColDesc("ColDateArray", "ARRAY<DATE>"),
+          new ColDesc("ColFloat64Array", "ARRAY<FLOAT64>"),
+          new ColDesc("ColInt64Array", "ARRAY<INT64>"),
+          new ColDesc("ColNumericArray", "ARRAY<NUMERIC>"),
+          new ColDesc("ColStringArray", "ARRAY<STRING(100)>"),
+          new ColDesc("ColStringMaxArray", "ARRAY<STRING(MAX)>"),
+          new ColDesc("ColTimestampArray", "ARRAY<TIMESTAMP>")};
+      testTableColumns(currentConnection, "TableWithAllLiquibaseTypes", cols);
 
-    testTablePrimaryKeys(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes",
-        new ColDesc("ColBigInt"));
-    
-    // Generate a snapshot of the database.
-    SnapshotGeneratorFactory factory = SnapshotGeneratorFactory.getInstance();
-    CatalogAndSchema schema = new CatalogAndSchema("", "");
-    SnapshotControl control = new SnapshotControl(liquibase.getDatabase());
-    DatabaseSnapshot snapshot = factory.createSnapshot(schema, liquibase.getDatabase(), control);
+      testTablePrimaryKeys(currentConnection, "TableWithAllLiquibaseTypes",
+          new ColDesc("ColBigInt"));
 
-    testSnapshotTableAndColumns(snapshot, "TableWithAllLiquibaseTypes", cols);
-    testSnapshotPrimaryKey(snapshot, "TableWithAllLiquibaseTypes",
-        new ColDesc("ColBigInt", "INT64", Boolean.FALSE));
-    
-    // Generate an initial changelog for the database.
-    File changeLogFile = File.createTempFile("test-changelog", ".xml");
-    changeLogFile.deleteOnExit();
-    Main.run(new String[] {
-        "--overwriteOutputFile=true",
-        String.format("--changeLogFile=%s", changeLogFile.getAbsolutePath()),
-        String.format("--url=%s", testHarness.getJDBCConnection().getMetaData().getURL()),
-        "generateChangeLog"});
-    DocumentBuilderFactory documentBuilderFactory =
-        DocumentBuilderFactory.newInstance();
-    DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
-    Document document = builder.parse(changeLogFile);
-    testTableColumnsInXml(document, "TableWithAllLiquibaseTypes", cols);
+      // Generate a snapshot of the database.
+      SnapshotGeneratorFactory factory = SnapshotGeneratorFactory.getInstance();
+      CatalogAndSchema schema = new CatalogAndSchema("", "");
+      SnapshotControl control = new SnapshotControl(liquibase.getDatabase());
+      DatabaseSnapshot snapshot = factory.createSnapshot(schema, liquibase.getDatabase(), control);
 
-    // Do rollback
-    liquibase.rollback(1, null);
+      testSnapshotTableAndColumns(snapshot, "TableWithAllLiquibaseTypes", cols);
+      testSnapshotPrimaryKey(snapshot, "TableWithAllLiquibaseTypes",
+          new ColDesc("ColBigInt", "INT64", Boolean.FALSE));
 
-    // Ensure nothing is there!
-    testTableColumns(testHarness.getJDBCConnection(), "TableWithAllLiquibaseTypes");
+      // Generate an initial changelog for the database.
+      File changeLogFile = File.createTempFile("test-changelog", ".xml");
+      changeLogFile.deleteOnExit();
+      Main.run(new String[] {"--overwriteOutputFile=true",
+          String.format("--changeLogFile=%s", changeLogFile.getAbsolutePath()),
+          String.format("--url=%s", testHarness.getConnectionUrl()), "generateChangeLog"});
+      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+      Document document = builder.parse(changeLogFile);
+      testTableColumnsInXml(document, "TableWithAllLiquibaseTypes", cols);
+
+      // Do rollback
+      liquibase.rollback(1, null);
+
+      // Ensure nothing is there!
+      testTableColumns(currentConnection, "TableWithAllLiquibaseTypes");
+    }
   }
 
   @Test
-  void doEmulatorSpannerGenerateChangeLogForInterleavedTableTest()
-      throws Exception {
+  void doEmulatorSpannerGenerateChangeLogForInterleavedTableTest() throws Exception {
     doSpannerGenerateChangeLogForInterleavedTableTest(getSpannerEmulator());
   }
 
   @Test
   @Tag("integration")
-  void doRealSpannerGenerateChangeLogForInterleavedTableTest()
-      throws Exception {
+  void doRealSpannerGenerateChangeLogForInterleavedTableTest() throws Exception {
     doSpannerGenerateChangeLogForInterleavedTableTest(getSpannerReal());
   }
-  
+
   private void doSpannerGenerateChangeLogForInterleavedTableTest(TestHarness.Connection testHarness)
       throws Exception {
-    try (Statement statement = testHarness.getJDBCConnection().createStatement()) {
-      // Create a parent and child table manually.
-      statement
-          .addBatch("CREATE TABLE Singers (SingerId INT64, Name STRING(200)) PRIMARY KEY (SingerId)");
-      statement.addBatch(
-          "CREATE TABLE Albums (SingerId INT64, AlbumId INT64, Title STRING(MAX)) PRIMARY KEY (SingerId, AlbumId), INTERLEAVE IN PARENT Singers");
-      statement.addBatch(
-          "CREATE TABLE Concerts (ConcertId INT64, SingerId INT64, CONSTRAINT FK_Concerts_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId)) PRIMARY KEY (ConcertId)");
-      statement.executeBatch();
-      
-      try {
-        // Generate an initial changelog for the database.
-        File changeLogFile = File.createTempFile("test-changelog", ".xml");
-        changeLogFile.deleteOnExit();
-        Main.run(new String[] {"--overwriteOutputFile=true",
-            String.format("--changeLogFile=%s", changeLogFile.getAbsolutePath()),
-            String.format("--url=%s", testHarness.getJDBCConnection().getMetaData().getURL()),
-            "generateChangeLog"});
-    
-        // Verify that the generated change log only includes one foreign key.
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
-        Document document = builder.parse(changeLogFile);
-        XPathFactory xPathfactory = XPathFactory.newInstance();
-        XPath xpath = xPathfactory.newXPath();
-        XPathExpression expr = xpath.compile(String.format("//addForeignKeyConstraint", document));
-        NodeList createForeignKeys = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
-        assertEquals(1, createForeignKeys.getLength());
-        Node createForeignKey = createForeignKeys.item(0);
-        assertEquals("FK_Concerts_Singers",
-            createForeignKey.getAttributes().getNamedItem("constraintName").getNodeValue());
-      } finally {
-        statement.addBatch("DROP TABLE Concerts");
-        statement.addBatch("DROP TABLE Albums");
-        statement.addBatch("DROP TABLE Singers");
+    try (Connection connection = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      try (Statement statement = connection.createStatement()) {
+        // Create a parent and child table manually.
+        statement.addBatch(
+            "CREATE TABLE Singers (SingerId INT64, Name STRING(200)) PRIMARY KEY (SingerId)");
+        statement.addBatch(
+            "CREATE TABLE Albums (SingerId INT64, AlbumId INT64, Title STRING(MAX)) PRIMARY KEY (SingerId, AlbumId), INTERLEAVE IN PARENT Singers");
+        statement.addBatch(
+            "CREATE TABLE Concerts (ConcertId INT64, SingerId INT64, CONSTRAINT FK_Concerts_Singers FOREIGN KEY (SingerId) REFERENCES Singers (SingerId)) PRIMARY KEY (ConcertId)");
         statement.executeBatch();
+
+        try {
+          // Generate an initial changelog for the database.
+          File changeLogFile = File.createTempFile("test-changelog", ".xml");
+          changeLogFile.deleteOnExit();
+          Main.run(new String[] {"--overwriteOutputFile=true",
+              String.format("--changeLogFile=%s", changeLogFile.getAbsolutePath()),
+              String.format("--url=%s", testHarness.getConnectionUrl()), "generateChangeLog"});
+
+          // Verify that the generated change log only includes one foreign key.
+          DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+          DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+          Document document = builder.parse(changeLogFile);
+          XPathFactory xPathfactory = XPathFactory.newInstance();
+          XPath xpath = xPathfactory.newXPath();
+          XPathExpression expr =
+              xpath.compile(String.format("//addForeignKeyConstraint", document));
+          NodeList createForeignKeys = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+          assertEquals(1, createForeignKeys.getLength());
+          Node createForeignKey = createForeignKeys.item(0);
+          assertEquals("FK_Concerts_Singers",
+              createForeignKey.getAttributes().getNamedItem("constraintName").getNodeValue());
+        } finally {
+          statement.addBatch("DROP TABLE Concerts");
+          statement.addBatch("DROP TABLE Albums");
+          statement.addBatch("DROP TABLE Singers");
+          statement.executeBatch();
+        }
       }
     }
   }
@@ -646,12 +631,15 @@ public class LiquibaseTests {
     public final String name;
     public final String type;
     public final Boolean isNullable;
+
     public ColDesc(String name) {
       this(name, null, Boolean.TRUE);
     }
+
     public ColDesc(String name, String type) {
       this(name, type, Boolean.TRUE);
     }
+
     public ColDesc(String name, String type, Boolean isNullable) {
       this.name = name;
       this.type = type;
@@ -723,16 +711,15 @@ public class LiquibaseTests {
 
     Assert.assertEquals(rows.size(), cols.length);
     for (int i = 0; i < cols.length; i++) {
-      Assert.assertEquals(
-          rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name),
-          0);
+      Assert.assertEquals(rows.get(i).get("COLUMN_NAME").toString().compareTo(cols[i].name), 0);
     }
   }
-  
-  static void testSnapshotTableAndColumns(DatabaseSnapshot snapshot, String tableName, ColDesc... cols) {
+
+  static void testSnapshotTableAndColumns(DatabaseSnapshot snapshot, String tableName,
+      ColDesc... cols) {
     Table table = snapshot.get(new Table("", "", tableName));
     assertThat(table).isNotNull();
-    
+
     for (ColDesc col : cols) {
       Column column = snapshot.get(new Column(Table.class, "", "", tableName, col.name));
       assertThat(column).isNotNull();
@@ -740,12 +727,12 @@ public class LiquibaseTests {
       assertThat(column.isNullable()).isEqualTo(col.isNullable);
     }
   }
-  
+
   static void testSnapshotPrimaryKey(DatabaseSnapshot snapshot, String tableName, ColDesc... cols) {
     Table table = snapshot.get(new Table("", "", tableName));
     assertThat(table.getPrimaryKey().getColumns()).hasSize(cols.length);
     List<Column> snapshotColumns = table.getPrimaryKey().getColumns();
-    for (int i=0; i<cols.length; i++) {
+    for (int i = 0; i < cols.length; i++) {
       Column column = snapshotColumns.get(i);
       assertThat(cols[i].name).isEqualTo(column.getName());
       assertThat(cols[i].type).isEqualTo(column.getType().getTypeName());
@@ -768,7 +755,7 @@ public class LiquibaseTests {
   static List<Map<String, Object>> getResults(ResultSet rs) throws SQLException {
     ArrayList<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
     while (rs.next()) {
-      Map rowVals = new HashMap<String, Object>();
+      Map<String, Object> rowVals = new HashMap<>();
       for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
         String columnName = rs.getMetaData().getColumnName(i);
         if (columnName.equals("")) {
@@ -798,50 +785,55 @@ public class LiquibaseTests {
     doSetNullableTest(getSpannerReal());
   }
 
-  void doSetNullableTest(TestHarness.Connection testHarness)
-      throws SQLException, LiquibaseException {
-    // Create a simple table.
-    Statement statement = testHarness.getJDBCConnection().createStatement();
-    statement.execute("START BATCH DDL");
-    statement.execute(
-          "CREATE TABLE Singers (\n"
-        + "  SingerId INT64 NOT NULL,\n"
-        + "  LastName STRING(100),\n"
-        + ") PRIMARY KEY (SingerId)");
-    statement.execute("RUN BATCH");
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isTrue();
+  void doSetNullableTest(TestHarness.Connection testHarness) throws Exception {
+    try (Connection connection = DriverManager.getConnection(testHarness.getConnectionUrl())) {
+      // Create a simple table.
+      Statement statement = connection.createStatement();
+      statement.execute("START BATCH DDL");
+      statement.execute("CREATE TABLE Singers (\n" + "  SingerId INT64 NOT NULL,\n"
+          + "  LastName STRING(100),\n" + ") PRIMARY KEY (SingerId)");
+      statement.execute("RUN BATCH");
+      assertThat(isNullable(connection, "Singers", "LastName")).isTrue();
 
-    // Run a Liquibase update to make the LastName column NOT NULL.
-    Liquibase makeNotNull = getLiquibase(testHarness,
-        "add-not-null-constraint-singers-lastname.spanner.yaml");
-    makeNotNull.update(new Contexts("test"));
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isFalse();
+      // Run a Liquibase update to make the LastName column NOT NULL.
+      try (Liquibase makeNotNull =
+          getLiquibase(testHarness, "add-not-null-constraint-singers-lastname.spanner.yaml")) {
+        makeNotNull.update(new Contexts("test"));
+        Connection currentConnection =
+            ((JdbcConnection) makeNotNull.getDatabase().getConnection()).getUnderlyingConnection();
+        assertThat(isNullable(currentConnection, "Singers", "LastName")).isFalse();
 
-    // Do rollback.
-    makeNotNull.rollback(1, "test");
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isTrue();
-    
-    // Manually make the column NOT NULL.
-    statement.execute("START BATCH DDL");
-    statement.execute("ALTER TABLE Singers ALTER COLUMN LastName STRING(100) NOT NULL");
-    statement.execute("RUN BATCH");
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isFalse();
-    
-    Liquibase makeNullable = getLiquibase(testHarness,
-        "drop-not-null-constraint-singers-lastname.spanner.yaml");
-    makeNullable.update(new Contexts("test"));
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isTrue();
+        // Do rollback.
+        makeNotNull.rollback(1, "test");
+        assertThat(isNullable(currentConnection, "Singers", "LastName")).isTrue();
 
-    // Do rollback.
-    makeNullable.rollback(1, "test");
-    assertThat(isNullable(testHarness.getJDBCConnection(), "Singers", "LastName")).isFalse();
-    
-    statement.execute("START BATCH DDL");
-    statement.execute("DROP TABLE Singers");
-    statement.execute("RUN BATCH");
+        // Manually make the column NOT NULL.
+        statement.execute("START BATCH DDL");
+        statement.execute("ALTER TABLE Singers ALTER COLUMN LastName STRING(100) NOT NULL");
+        statement.execute("RUN BATCH");
+        assertThat(isNullable(currentConnection, "Singers", "LastName")).isFalse();
+      }
+
+      try (Liquibase makeNullable =
+          getLiquibase(testHarness, "drop-not-null-constraint-singers-lastname.spanner.yaml")) {
+        makeNullable.update(new Contexts("test"));
+        Connection currentConnection =
+            ((JdbcConnection) makeNullable.getDatabase().getConnection()).getUnderlyingConnection();
+        assertThat(isNullable(currentConnection, "Singers", "LastName")).isTrue();
+
+        // Do rollback.
+        makeNullable.rollback(1, "test");
+        assertThat(isNullable(currentConnection, "Singers", "LastName")).isFalse();
+      }
+
+      statement.execute("START BATCH DDL");
+      statement.execute("DROP TABLE Singers");
+      statement.execute("RUN BATCH");
+    }
   }
-  
-  static boolean isNullable(java.sql.Connection conn, String table, String column) throws SQLException {
+
+  static boolean isNullable(java.sql.Connection conn, String table, String column)
+      throws SQLException {
     try (ResultSet rs = conn.getMetaData().getColumns(null, null, table, column)) {
       while (rs.next()) {
         return "YES".equalsIgnoreCase(rs.getString("IS_NULLABLE"));

--- a/src/test/java/com/google/spanner/liquibase/TestHarness.java
+++ b/src/test/java/com/google/spanner/liquibase/TestHarness.java
@@ -40,11 +40,9 @@ public class TestHarness {
    * Interface for a Liquibase JDBC Test Harness
    */
   public interface Connection {
-
-    // Return the active JDBC connection.
-    //
-    // This will reuse JDBC connections between tests.
-    java.sql.Connection getJDBCConnection();
+    
+    // Returns the connection URL that is used by this connection.
+    String getConnectionUrl();
 
     // Stop() stops the test Spanner database and does any needed cleanup.
     void stop() throws SQLException;
@@ -174,24 +172,20 @@ public class TestHarness {
     createInstance(service, INSTANCE_ID);
     createDatabase(service, INSTANCE_ID, DATABASE_ID);
 
-    // JDBC Connection
-    final java.sql.Connection conn =
-        DriverManager.getConnection(
-            String.format(
-                "jdbc:cloudspanner://%s/projects/%s/instances/%s/databases/%s?autocommit=false;usePlainText=true",
-                spannerEmulatorHost, PROJECT_ID, INSTANCE_ID, DATABASE_ID));
+    final String connectionUrl = String.format(
+        "jdbc:cloudspanner://%s/projects/%s/instances/%s/databases/%s?autocommit=true;usePlainText=true",
+        spannerEmulatorHost, PROJECT_ID, INSTANCE_ID, DATABASE_ID); 
 
     return new Connection() {
-
+      
       @Override
-      public java.sql.Connection getJDBCConnection() {
-        return conn;
+      public String getConnectionUrl() {
+        return connectionUrl;
       }
 
       @Override
       public void stop() throws SQLException {
         service.close();
-        conn.close();
         try {
           ConnectionOptions.closeSpanner();
         } catch (SpannerException e) {
@@ -224,18 +218,19 @@ public class TestHarness {
 
     createDatabase(service, instanceId, databaseId);
 
+    final String connectionUrl = 
+        String.format(
+            "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s?autocommit=true",
+            projectId, instanceId, databaseId);
     // JDBC connection initialize
     java.sql.Connection conn =
-        DriverManager.getConnection(
-            String.format(
-                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s?autocommit=true",
-                projectId, instanceId, databaseId));
+        DriverManager.getConnection(connectionUrl);
 
     return new Connection() {
-
+      
       @Override
-      public java.sql.Connection getJDBCConnection() {
-        return conn;
+      public String getConnectionUrl() {
+        return connectionUrl;
       }
 
       @Override

--- a/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
+++ b/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
@@ -318,7 +318,7 @@ public abstract class AbstractMockServerTest {
   }
   
   @AfterEach
-  void checkValidRequest() {
+  void checkForLiquibaseToken() {
     if (receivedRequestWithNonLiquibaseToken.get()) {
       // Clear flag for following tests.
       receivedRequestWithNonLiquibaseToken.set(false);

--- a/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
+++ b/src/test/java/liquibase/ext/spanner/AbstractMockServerTest.java
@@ -1,5 +1,6 @@
 package liquibase.ext.spanner;
 
+import static org.junit.Assert.fail;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
@@ -21,7 +22,14 @@ import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
 import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Metadata.Key;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -30,12 +38,14 @@ import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.concurrent.atomic.AtomicBoolean;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 
 public abstract class AbstractMockServerTest {
@@ -103,6 +113,8 @@ public abstract class AbstractMockServerTest {
   protected static MockDatabaseAdminImpl mockAdmin;
   private static Server server;
   private static InetSocketAddress address;
+  protected static AtomicBoolean receivedRequestWithNonLiquibaseToken = new AtomicBoolean();
+  private static String invalidClientLibToken;
 
   @BeforeAll
   static void startStaticServer() throws IOException {
@@ -110,12 +122,33 @@ public abstract class AbstractMockServerTest {
     mockSpanner.setAbortProbability(0.0D);
     mockAdmin = new MockDatabaseAdminImpl();
     address = new InetSocketAddress("localhost", 0);
-    server =
-        NettyServerBuilder.forAddress(address)
-            .addService(mockSpanner)
-            .addService(mockAdmin)
-            .build()
-            .start();
+    server = NettyServerBuilder.forAddress(address).addService(mockSpanner).addService(mockAdmin)
+        // Add a server interceptor that will check that we receive the client lib
+        // token that we expect.
+        .intercept(new ServerInterceptor() {
+          @Override
+          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+              Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            // Ignore create/delete session and execute query calls. Some other
+            // database drivers try to execute a query to check whether the
+            // backend is the 'right' database, instead of at least checking the driver first...
+            if (!(call.getMethodDescriptor().getFullMethodName()
+                .equals("google.spanner.v1.Spanner/BatchCreateSessions")
+                || call.getMethodDescriptor().getFullMethodName()
+                    .equals("google.spanner.v1.Spanner/ExecuteStreamingSql")
+                || call.getMethodDescriptor().getFullMethodName()
+                    .equals("google.spanner.v1.Spanner/DeleteSession"))) {
+              String clientLibToken =
+                  headers.get(Key.of("x-goog-api-client", Metadata.ASCII_STRING_MARSHALLER));
+              if (clientLibToken == null || !clientLibToken.contains("sp-liq")) {
+                if (!receivedRequestWithNonLiquibaseToken.getAndSet(true)) {
+                  invalidClientLibToken = clientLibToken;
+                }
+              }
+            }
+            return Contexts.interceptCall(Context.current(), call, headers, next);
+          }
+        }).build().start();
 
     registerDefaultResults();
   }
@@ -283,6 +316,15 @@ public abstract class AbstractMockServerTest {
     server.shutdown();
     server.awaitTermination();
   }
+  
+  @AfterEach
+  void checkValidRequest() {
+    if (receivedRequestWithNonLiquibaseToken.get()) {
+      // Clear flag for following tests.
+      receivedRequestWithNonLiquibaseToken.set(false);
+      fail("Server received request with invalid client lib token: " + invalidClientLibToken);
+    }
+  }
 
   static ResultSet createInt64ResultSet(long value) {
     return com.google.spanner.v1.ResultSet.newBuilder()
@@ -323,6 +365,16 @@ public abstract class AbstractMockServerTest {
                 .findCorrectDatabaseImplementation(new JdbcConnection(connection)));
     return liquibase;
   }
+  
+  protected static Liquibase getLiquibase(String connectionUrl, String changeLogFile) throws DatabaseException {
+    Liquibase liquibase =
+        new Liquibase(
+            changeLogFile,
+            new ClassLoaderResourceAccessor(),
+            DatabaseFactory.getInstance()
+                .openDatabase(connectionUrl, null, null, null, null));
+    return liquibase;
+  }
 
   static void addUpdateDdlStatementsResponse(String statement) {
     addUpdateDdlStatementsResponse(ImmutableList.of(statement));
@@ -349,10 +401,13 @@ public abstract class AbstractMockServerTest {
   }
 
   protected static Connection createConnection() throws SQLException {
-    StringBuilder url =
+    return DriverManager.getConnection(createConnectionUrl());
+  }
+  
+  protected static String createConnectionUrl() {
+    return
         new StringBuilder("jdbc:cloudspanner://localhost:")
             .append(server.getPort())
-            .append("/projects/p/instances/i/databases/d;usePlainText=true");
-    return DriverManager.getConnection(url.toString());
+            .append("/projects/p/instances/i/databases/d;usePlainText=true;minSessions=0").toString();
   }
 }

--- a/src/test/java/liquibase/ext/spanner/GenerateSnapshotTest.java
+++ b/src/test/java/liquibase/ext/spanner/GenerateSnapshotTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.Statement;
 import com.google.common.collect.ImmutableList;
-import java.sql.Connection;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -135,8 +134,7 @@ public class GenerateSnapshotTest extends AbstractMockServerTest {
 
   @Test
   void testGenerateSnapshot() throws Exception {
-    try (Connection con = createConnection();
-        Liquibase liquibase = getLiquibase(con, "create-snapshot.spanner.yaml")) {
+    try (Liquibase liquibase = getLiquibase(createConnectionUrl(), "create-snapshot.spanner.yaml")) {
       SnapshotGeneratorFactory factory = SnapshotGeneratorFactory.getInstance();
       Database database = liquibase.getDatabase();
       SnapshotControl control = new SnapshotControl(database);

--- a/src/test/java/liquibase/ext/spanner/SimpleMockServerTest.java
+++ b/src/test/java/liquibase/ext/spanner/SimpleMockServerTest.java
@@ -25,6 +25,12 @@ public class SimpleMockServerTest extends AbstractMockServerTest {
     assertThat(mockAdmin.getRequests()).hasSize(1);
     assertThat(mockAdmin.getRequests().get(0)).isInstanceOf(UpdateDatabaseDdlRequest.class);
     assertThat(getUpdateDdlStatementsList(0)).containsExactly(statement).inOrder();
+    
+    // This test does not use Liquibase but JDBC directly, so it is expected to send requests that
+    // do not contain a Liquibase client lib token.
+    assertThat(receivedRequestWithNonLiquibaseToken.get()).isTrue();
+    // Clear the flag to prevent the check after each test to fail.
+    receivedRequestWithNonLiquibaseToken.set(false);
   }
 
   @Test


### PR DESCRIPTION
- Updates the JDBC driver to version 2.0.
- Sets the user-agent string (technically: clientLibToken) to `sp-liq` to indicate that the requests are going through Liquibase.
- Re-factors the `LiquibaseTests` and `TestHarness` to no longer reuse the same JDBC connection for each test, as the `Liquibase` object is `AutoCloseable`, which means that each instance should preferably be opened and closed within one try-with-resources block when possible.
