### PR TITLE
build: increase integration test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           name: "Run integration tests"
           command: |
             ./gradlew --no-daemon -PtagVersion=${CIRCLE_TAG} integrationTest
+          no_output_timeout: 30m
       - store_test_results:
           path: build/test-results/test
       - store_artifacts:


### PR DESCRIPTION
Increase the timeout for CircleCI when executing the integration tests. This has timed out a couple of times during the nightly builds.