### PR TITLE
docs: add sample for Spring Boot integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ bin/
 .settings/
 .idea/
 .vscode/
-/target/
+target/
 liquibase-spanner.iml

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Run:
 | [delete.yaml](example/delete.yaml)                                                         | Delete rows from Singers                                                  |
 | [update.yaml](example/update.yaml)                                                         | Update rows in Singers                                                    |
 
+### Other Samples
+See the samples directory for specific integrations with other frameworks, such as Spring Boot.
+
 ## Supported Features
 
 The following Liquibase [ChangeTypes](https://docs.liquibase.com/change-types/home.html) are supported:<br/>

--- a/samples/spanner-liquibase-spring-boot-sample/README.md
+++ b/samples/spanner-liquibase-spring-boot-sample/README.md
@@ -1,0 +1,12 @@
+
+# Liquibase Spanner Extension with Spring Boot Example
+
+Example project for setting up Google Cloud Spanner with Liquibase in a Spring Boot application.
+
+This example application shows how to:
+1. Use Liquibase to update and maintain a Cloud Spanner database in a Spring Boot application.
+2. Run and use the Spanner emulator in a Docker container in your application to test the integration of your application with Spanner without the need to set up a Cloud Spanner database.
+
+## Running the Sample
+
+Execute `mvn clean spring-boot:run` from the root of the project.

--- a/samples/spanner-liquibase-spring-boot-sample/pom.xml
+++ b/samples/spanner-liquibase-spring-boot-sample/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>spanner-liquibase-spring-boot-sample</artifactId>
+  <version>1.0</version>
+  <name>Spanner Liquibase with Spring Boot Example</name>
+
+  <properties>
+    <java.version>1.8</java.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+    <spanner-liquibase.version>1.0.3</spanner-liquibase.version>
+    <spanner-jdbc.version>2.1.0</spanner-jdbc.version>
+    <testcontainers.version>1.15.3</testcontainers.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloudspannerecosystem</groupId>
+        <artifactId>liquibase-spanner</artifactId>
+        <version>${spanner-liquibase.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloudspannerecosystem</groupId>
+      <artifactId>liquibase-spanner</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/spanner-liquibase-spring-boot-sample/src/main/java/com/google/cloud/spanner/liquibase/sample/SampleSpringBootApplication.java
+++ b/samples/spanner-liquibase-spring-boot-sample/src/main/java/com/google/cloud/spanner/liquibase/sample/SampleSpringBootApplication.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.spanner.liquibase.sample;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+@SpringBootApplication
+public class SampleSpringBootApplication {
+  /** This sample application uses a Spanner emulator that runs in a Docker container. */
+  private static GenericContainer<?> emulator;
+
+  public static void main(String[] args) {
+    // Start the Spanner emulator before starting the Spring Boot application.
+    System.out.println("Starting Spanner emulator");
+    startSpannerEmulator();
+    SpringApplication.run(SampleSpringBootApplication.class, args);
+
+    // Stop the emulator and shutdown the application.
+    stopSpannerEmulator();
+    System.out.println("Stopped Spanner emulator");
+    System.exit(0);
+  }
+
+  @Bean
+  public CommandLineRunner init(DataSource datasource) {
+    return args -> {
+      // Insert a row in the table that was created by Liquibase and select all rows from the table.
+      try (Connection connection = datasource.getConnection()) {
+        try (PreparedStatement statement = connection.prepareStatement(
+            "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (?, ?, ?)")) {
+          statement.setString(1, UUID.randomUUID().toString());
+          statement.setString(2, "Peter");
+          statement.setString(3, "Allison");
+          System.out.printf("Inserted %d records\n", statement.executeUpdate());
+        }
+        try (ResultSet resultSet =
+            connection.createStatement().executeQuery("SELECT * FROM Singers")) {
+          while (resultSet.next()) {
+            System.out.printf("Found singer: %s - %s %s\n", resultSet.getString(1),
+                resultSet.getString(2), resultSet.getString(3));
+          }
+        }
+      }
+    };
+  }
+
+  /**
+   * The datasource is dynamically generated, as the mapped port of the emulator on the Docker
+   * container is variable.
+   */
+  @Bean
+  public DataSource datasource() {
+    DataSourceBuilder<?> builder = DataSourceBuilder.create();
+    builder.driverClassName("com.google.cloud.spanner.jdbc.JdbcDriver");
+    builder.url(String.format(
+        // autoConfigEmulator=true ensures that the connection will use plain text, and it will
+        // automatically create the instance and database that is named in the connection string (if
+        // they do not already exist).
+        "jdbc:cloudspanner://localhost:%d/projects/test-project/instances/test-instance/databases/testdb;autoConfigEmulator=true",
+        emulator.getMappedPort(9010)));
+    return builder.build();
+  }
+
+  @SuppressWarnings("resource")
+  static void startSpannerEmulator() {
+    String SPANNER_EMULATOR_IMAGE = "gcr.io/cloud-spanner-emulator/emulator:latest";
+    emulator = new GenericContainer<>(SPANNER_EMULATOR_IMAGE).withCommand()
+        .withExposedPorts(9010, 9020).withStartupTimeout(Duration.ofSeconds(10))
+        .waitingFor(Wait.forHttp("/").forStatusCode(404));
+    emulator.start();
+  }
+
+  static void stopSpannerEmulator() {
+    emulator.stop();
+  }
+}

--- a/samples/spanner-liquibase-spring-boot-sample/src/main/resources/db/changelog/db.changelog-1.0.yaml
+++ b/samples/spanner-liquibase-spring-boot-sample/src/main/resources/db/changelog/db.changelog-1.0.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      author: some-developer
+      id: create-singers-table
+      changes:
+        - createTable:
+            tableName: Singers
+            columns:
+              - column:
+                  name: SingerId
+                  type: STRING(36)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: FirstName
+                  type: STRING(200)
+              - column:
+                  name: LastName
+                  type: STRING(200)

--- a/samples/spanner-liquibase-spring-boot-sample/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/samples/spanner-liquibase-spring-boot-sample/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/db.changelog-1.0.yaml


### PR DESCRIPTION
Adds a working sample application for using Liquibase with Cloud Spanner in a Spring Boot application.

See discussion in https://github.com/cloudspannerecosystem/liquibase-spanner/issues/74
