### PR TITLE
build: follow Liquibase version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Cloud Spanner database.
 
 ## Release Notes
 
+#### 4.4.3
+* Requires Liquibase 4.4.3.
+* The version of this library now mirrors the version number of the Liquibase version that it requires.
+
 #### 1.0.5
 
 * Added sample for Spring Boot integration

--- a/build.gradle
+++ b/build.gradle
@@ -71,13 +71,14 @@ dependencies {
     implementation("com.google.cloud:google-cloud-spanner-jdbc")
 
     // Liquibase Core - needed for testing and docker container
-    implementation("org.liquibase:liquibase-core:4.3.2")
+    implementation("org.liquibase:liquibase-core:4.4.3")
     implementation("org.yaml:snakeyaml:1.26")
     implementation("org.apache.commons:commons-lang3:3.11")
 
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.testcontainers:testcontainers:1.15.1")
+    testImplementation("org.testcontainers:testcontainers:1.15.3")
+    testImplementation("net.java.dev.jna:jna:5.8.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("com.google.truth:truth:1.0.1")
     testImplementation("org.mockito:mockito-core:1.10.19")
@@ -96,7 +97,7 @@ dependencies {
     
     // For Spanner mock server testing
     testImplementation(group: 'com.google.cloud', name: 'google-cloud-spanner', classifier: 'tests')
-    testImplementation(group: 'com.google.api', name: 'gax-grpc', version: '1.60.0', classifier: 'testlib')
+    testImplementation(group: 'com.google.api', name: 'gax-grpc', version: '2.4.0', classifier: 'testlib')
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>liquibase-spanner</artifactId>
-  <version>1.0.5</version>
+  <version>${liquibase.version}</version>
   <packaging>jar</packaging>
   <name>Google Cloud Spanner Liquibase Integeration</name>
   <description>Liquibase extension for Google Cloud Spanner</description>
@@ -52,12 +52,12 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <liquibase.version>4.3.2</liquibase.version>
+    <liquibase.version>4.4.3</liquibase.version>
     <snakeyaml.version>1.26</snakeyaml.version>
 
-    <gax-grpc.version>1.60.0</gax-grpc.version>
+    <gax-grpc.version>2.4.0</gax-grpc.version>
     <jupiter.version>5.6.2</jupiter.version>
-    <testcontainers.version>1.13.0</testcontainers.version>
+    <testcontainers.version>1.15.3</testcontainers.version>
     <truth.version>1.0.1</truth.version>
     <mockito.version>1.10.19</mockito.version>
   </properties>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>20.0.0</version>
+        <version>22.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -136,6 +136,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -206,7 +206,6 @@ public class LiquibaseTests {
     }
   }
 
-  @Disabled("The emulator erroneously requires the optional COLUMN keyword to be included in ALTER TABLE <table> ADD [COLUMN] ...")
   @Test
   void doEmulatorMergeColumnsTest() throws Exception {
     doMergeColumnsTest(getSpannerEmulator());


### PR DESCRIPTION
This library should use the same version number as the Liquibase version that it
depends on. This reduces the chance of confusion for end users as to which version
of this library they should use.

This is also the strategy that for example the Snowflake Liquibase extension follows: https://github.com/liquibase/liquibase-snowflake/tags

Fixes #98