### PR TITLE
deps: bump Liquibase to 4.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Cloud Spanner database.
 
 ## Release Notes
 
+#### 4.10.0
+* Requires Liquibase 4.10.0
+
 #### 4.9.1
 * Requires Liquibase 4.9.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation("com.google.cloud:google-cloud-spanner-jdbc")
 
     // Liquibase Core - needed for testing and docker container
-    implementation("org.liquibase:liquibase-core:4.9.1")
+    implementation("org.liquibase:liquibase-core:4.10.0")
     implementation("org.yaml:snakeyaml:1.26")
     implementation("org.apache.commons:commons-lang3:3.11")
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <liquibase.version>4.9.1</liquibase.version>
+    <liquibase.version>4.10.0</liquibase.version>
     <snakeyaml.version>1.26</snakeyaml.version>
 
     <gax-grpc.version>2.4.0</gax-grpc.version>

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateTableStatementSpanner.java
@@ -60,7 +60,17 @@ public class CreateTableStatementSpanner extends CreateTableStatement {
     return statement;
   }
 
-    private boolean containsNotNullConstraintForColumn(String column, ColumnConstraint... constraints) {
+  @Override
+  public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
+      Boolean validate, boolean deferrable, boolean initiallyDeferred, String keyName, String tablespace, String remarks, ColumnConstraint... constraints) {
+    CreateTableStatement statement = super.addPrimaryKeyColumn(columnName, columnType, defaultValue, validate, deferrable, initiallyDeferred, keyName, tablespace, remarks, constraints);
+    if (!containsNotNullConstraintForColumn(columnName, constraints)) {
+      getNotNullColumns().remove(columnName);
+    }
+    return statement;
+  }
+
+  private boolean containsNotNullConstraintForColumn(String column, ColumnConstraint... constraints) {
     for (ColumnConstraint constraint : constraints) {
       if (constraint instanceof NotNullConstraint) {
         NotNullConstraint nn = (NotNullConstraint) constraint;


### PR DESCRIPTION
Bumps Liquibase to 4.10.0 and adds a new overwrite for `CreateTableStatement`, as an additional method for adding a primary key has been added in 4.10.0. This method needs to be overridden in Spanner in order to correctly configure nullable primary key constraints for Spanner.

This PR is the reason that a small code change is needed to support Liquibase 4.10.0: https://github.com/liquibase/liquibase/pull/2752