### PR TITLE
docs: remove DEFAULT values limitation

### DIFF
--- a/limitations.md
+++ b/limitations.md
@@ -21,7 +21,6 @@ The following database features are not supported by Cloud Spanner, and trying t
 
 - Auto increment columns
 - Sequences
-- Default value definition for a column
 - Unique constraints: Use `UNIQUE INDEX` instead of `UNIQUE CONSTRAINT`
 - Stored procedures
 - Table and column remarks


### PR DESCRIPTION
Cloud Spanner now supports `DEFAULT` values, so this limitation can be removed.