### PR TITLE
Bump Liquibase and dependency versions.

### DIFF
--- a/.github/workflows/.gitignore
+++ b/.github/workflows/.gitignore
@@ -1,0 +1,1 @@
+build.yml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ bin/
 .vscode/
 target/
 liquibase-spanner.iml
+.DS_Store
+
+*.log
+Dockerfile
+docker_run.sh

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@
 plugins {
     id "java"
     id "groovy"
-    id "com.google.cloud.tools.jib" version "2.7.0"
-    id "com.github.johnrengelman.shadow" version "6.0.0"
-    id "com.github.harbby.gradle.serviceloader" version "1.1.2"
+    id "com.google.cloud.tools.jib" version "3.3.1"
+    id "com.github.johnrengelman.shadow" version "6.1.0"
+    id "com.github.harbby.gradle.serviceloader" version "1.1.5"
 }
 
 
@@ -67,37 +67,37 @@ serviceLoader {
 dependencies {
 
     // Cloud Spanner related
-    implementation platform('com.google.cloud:libraries-bom:23.1.0')
+    implementation platform('com.google.cloud:libraries-bom:24.3.0')
     implementation("com.google.cloud:google-cloud-spanner-jdbc")
 
     // Liquibase Core - needed for testing and docker container
-    implementation("org.liquibase:liquibase-core:4.17.0")
-    implementation("org.yaml:snakeyaml:1.26")
-    implementation("org.apache.commons:commons-lang3:3.11")
+    implementation("org.liquibase:liquibase-core:4.17.2")
+    implementation("org.yaml:snakeyaml:1.33")
+    implementation("org.apache.commons:commons-lang3:3.12.0")
 
     // Testing
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.testcontainers:testcontainers:1.15.3")
-    testImplementation("net.java.dev.jna:jna:5.8.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("com.google.truth:truth:1.0.1")
-    testImplementation("org.mockito:mockito-core:1.10.19")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testImplementation("org.testcontainers:testcontainers:1.17.6")
+    testImplementation("net.java.dev.jna:jna:5.12.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testImplementation("com.google.truth:truth:1.1.3")
+    testImplementation("org.mockito:mockito-core:3.12.4")
 
     // For using the Liquibase test harness
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.liquibase:liquibase-test-harness:1.0.0'
-    testImplementation('org.codehaus.groovy:groovy-all:2.5.7') {
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.liquibase:liquibase-test-harness:1.0.7'
+    testImplementation('org.codehaus.groovy:groovy-all:2.5.20') {
         exclude module: 'org.codehaus.groovy:groovy-testng'
         exclude module: 'org.codehaus.groovy:groovy-swing'
     }
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
 
     // For testing runtime
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.1")
     
     // For Spanner mock server testing
     testImplementation(group: 'com.google.cloud', name: 'google-cloud-spanner', classifier: 'tests')
-    testImplementation(group: 'com.google.api', name: 'gax-grpc', version: '2.4.0', classifier: 'testlib')
+    testImplementation(group: 'com.google.api', name: 'gax-grpc', version: '2.20.1', classifier: 'testlib')
 }
 
 
@@ -173,4 +173,3 @@ jib {
         mainClass = 'liquibase.integration.commandline.Main'
     }
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,11 @@
     <liquibase.version>4.17.0</liquibase.version>
     <snakeyaml.version>1.33</snakeyaml.version>
 
-    <gax-grpc.version>2.4.0</gax-grpc.version>
-    <jupiter.version>5.6.2</jupiter.version>
-    <testcontainers.version>1.17.5</testcontainers.version>
-    <truth.version>1.0.1</truth.version>
-    <mockito.version>1.10.19</mockito.version>
+    <gax-grpc.version>2.21.0</gax-grpc.version>
+    <jupiter.version>5.9.1</jupiter.version>
+    <testcontainers.version>1.17.6</testcontainers.version>
+    <truth.version>1.1.3</truth.version>
+    <mockito.version>4.11.0</mockito.version>
   </properties>
 
   <dependencyManagement>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>23.1.0</version>
+        <version>24.3.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -87,7 +87,7 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
     </dependency>
-    
+
     <!-- Liquibase test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -98,13 +98,13 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-test-harness</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.7</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.5.7</version>
+      <version>2.5.20</version>
       <type>pom</type>
       <exclusions>
         <exclusion>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>1.3-groovy-2.5</version>
+      <version>2.3-groovy-2.5</version>
       <scope>test</scope>
     </dependency>
 
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.8.0</version>
+      <version>5.12.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -244,6 +244,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
         <configuration>
             <source>1.8</source>
             <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <liquibase.version>4.17.0</liquibase.version>
+    <liquibase.version>4.17.2</liquibase.version>
     <snakeyaml.version>1.33</snakeyaml.version>
 
     <gax-grpc.version>2.21.0</gax-grpc.version>

--- a/src/test/java/com/google/spanner/liquibase/TestHarness.java
+++ b/src/test/java/com/google/spanner/liquibase/TestHarness.java
@@ -143,7 +143,7 @@ public class TestHarness {
     if (spannerEmulatorHost == null) {
 
       // Create the container
-      final String SPANNER_EMULATOR_IMAGE = "gcr.io/cloud-spanner-emulator/emulator:1.2.0";
+      final String SPANNER_EMULATOR_IMAGE = "gcr.io/cloud-spanner-emulator/emulator:1.4.8";
       testContainer =
           new GenericContainer<>(SPANNER_EMULATOR_IMAGE)
               .withCommand()


### PR DESCRIPTION
Bump Liquibase to 4.17.2
Bump Google Cloud Libraries to BOM v24.3.0
Bump gax-grpc to 2.21.0
Bump Jupiter to 5.9.1
Bump testcontainers to 1.17.6
Bump Google Truth to 1.1.3
Bump Mockito to 4.11.0
Bump Liquibase Test Harness to 1.0.7
Bump groovy-all to 2.5.20
Bump spock-core to 2.3-groovy2.5
Bump jna to 5.12.1
Bump Spanner emulator to 1.4.8