### PR TITLE
fix: support snapshotting indexes with include columns

### DIFF
--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package liquibase.ext.spanner.snapshotgenerator;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import liquibase.database.AbstractJdbcDatabase;
+import liquibase.database.Database;
+import liquibase.database.core.*;
+import liquibase.diff.compare.DatabaseObjectComparatorFactory;
+import liquibase.exception.DatabaseException;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.serializer.LiquibaseSerializable;
+import liquibase.snapshot.CachedRow;
+import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.JdbcDatabaseSnapshot;
+import liquibase.snapshot.JdbcDatabaseSnapshot.CachingDatabaseMetaData;
+import liquibase.snapshot.SnapshotControl;
+import liquibase.snapshot.jvm.IndexSnapshotGenerator;
+import liquibase.snapshot.jvm.JdbcSnapshotGenerator;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.*;
+import liquibase.util.StringUtil;
+
+import java.sql.DatabaseMetaData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Analyses the properties of a database index and creates an object representation ("snapshot").
+ */
+public class IndexSnapshotGeneratorSpanner extends IndexSnapshotGenerator {
+
+    /**
+     * This generator will be in all chains that import the Cloud Spanner provider, also if it is used in combination with other databases.
+     */
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (database instanceof ICloudSpanner) {
+            return PRIORITY_DATABASE;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
+        Database database = snapshot.getDatabase();
+        Relation exampleIndex = ((Index) example).getRelation();
+
+        String tableName = null;
+        Schema schema = null;
+        if (exampleIndex != null) {
+            tableName = exampleIndex.getName();
+            schema = exampleIndex.getSchema();
+        }
+
+        if (schema == null) {
+            schema = new Schema(database.getDefaultCatalogName(), database.getDefaultSchemaName());
+        }
+
+
+        for (int i = 0; i < ((Index) example).getColumns().size(); i++) {
+            ((Index) example).getColumns().set(i, ((Index) example).getColumns().get(i));
+        }
+
+        String exampleName = example.getName();
+        if (exampleName != null) {
+            exampleName = database.correctObjectName(exampleName, Index.class);
+        }
+
+        Map<String, Index> foundIndexes = new HashMap<>();
+        JdbcDatabaseSnapshot.CachingDatabaseMetaData databaseMetaData = null;
+        List<CachedRow> rs = null;
+        try {
+            databaseMetaData = ((JdbcDatabaseSnapshot) snapshot).getMetaDataFromCache();
+
+            rs = databaseMetaData.getIndexInfo(((AbstractJdbcDatabase) database).getJdbcCatalogName(schema), ((AbstractJdbcDatabase) database).getJdbcSchemaName(schema), tableName, exampleName);
+
+            for (CachedRow row : rs) {
+                String rawIndexName = row.getString("INDEX_NAME");
+                String indexName = cleanNameFromDatabase(rawIndexName, database);
+                String correctedIndexName = database.correctObjectName(indexName, Index.class);
+
+                if (indexName == null) {
+                    continue;
+                }
+                if ((exampleName != null) && !exampleName.equals(correctedIndexName)) {
+                    continue;
+                }
+                Short type = row.getShort("TYPE");
+                Boolean nonUnique = row.getBoolean("NON_UNIQUE");
+                if (nonUnique == null) {
+                    nonUnique = true;
+                }
+
+                String columnName = cleanNameFromDatabase(row.getString("COLUMN_NAME"), database);
+                Short position = row.getShort("ORDINAL_POSITION");
+                String definition = StringUtil.trimToNull(row.getString("FILTER_CONDITION"));
+
+                // Have we already seen/found this index? If not, let's read its properties!
+                Index returnIndex = foundIndexes.get(correctedIndexName);
+                if (returnIndex == null) {
+                    returnIndex = new Index();
+                    Relation relation = new Table();
+                    if ("V".equals(row.getString("INTERNAL_OBJECT_TYPE"))) {
+                        relation = new View();
+                    }
+                    returnIndex.setRelation(relation.setName(row.getString("TABLE_NAME")).setSchema(schema));
+                    returnIndex.setName(indexName);
+                    returnIndex.setUnique(!nonUnique);
+
+                    String tablespaceName = row.getString("TABLESPACE_NAME");
+                    if ((tablespaceName != null) && database.supportsTablespaces()) {
+                        returnIndex.setTablespace(tablespaceName);
+                    }
+
+                    if (type == DatabaseMetaData.tableIndexClustered) {
+                        returnIndex.setClustered(true);
+                    }
+                    foundIndexes.put(correctedIndexName, returnIndex);
+                }
+
+                if (position == null) {
+                    List<String> includedColumns = returnIndex.getAttribute("includedColumns", List.class);
+                    if (includedColumns == null) {
+                        includedColumns = new ArrayList<>();
+                        returnIndex.setAttribute("includedColumns", includedColumns);
+                    }
+                    includedColumns.add(columnName);
+                } else {
+                    if (position != 0) { //if really a column, position is 1-based.
+                        for (int i = returnIndex.getColumns().size(); i < position; i++) {
+                            returnIndex.getColumns().add(null);
+                        }
+
+                        // Is this column a simple column (definition == null)
+                        // or is it a computed expression (definition != null)
+                        if (definition == null) {
+                            String ascOrDesc;
+                            if (database instanceof Db2zDatabase) {
+                                ascOrDesc = row.getString("ORDER");
+                            } else {
+                                ascOrDesc = row.getString("ASC_OR_DESC");
+                            }
+                            Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : ("A".equals(ascOrDesc) ?
+                                Boolean.FALSE : null);
+                            returnIndex.getColumns().set(position - 1, new Column(columnName)
+                                .setDescending(descending).setRelation(returnIndex.getRelation()));
+                        } else {
+                            returnIndex.getColumns().set(position - 1, new Column()
+                                .setRelation(returnIndex.getRelation()).setName(definition, true));
+                        }
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            throw new DatabaseException(e);
+        }
+
+        if (exampleName != null) {
+            return foundIndexes.get(exampleName);
+        } else {
+            //prefer clustered version of the index
+            List<Index> nonClusteredIndexes = new ArrayList<>();
+            for (Index index : foundIndexes.values()) {
+                if (DatabaseObjectComparatorFactory.getInstance().isSameObject(index.getRelation(), exampleIndex, snapshot.getSchemaComparisons(), database)) {
+                    boolean actuallyMatches = false;
+                    if (database.isCaseSensitive()) {
+                        if (index.getColumnNames().equals(((Index) example).getColumnNames())) {
+                            actuallyMatches = true;
+                        }
+                    } else {
+                        if (index.getColumnNames().equalsIgnoreCase(((Index) example).getColumnNames())) {
+                            actuallyMatches = true;
+                        }
+                    }
+                    if (actuallyMatches) {
+                        if ((index.getClustered() != null) && index.getClustered()) {
+                            return finalizeIndex(schema, tableName, index, snapshot);
+                        } else {
+                            nonClusteredIndexes.add(index);
+                        }
+                    }
+                }
+            }
+            if (!nonClusteredIndexes.isEmpty()) {
+                return finalizeIndex(schema, tableName, nonClusteredIndexes.get(0), snapshot);
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
@@ -14,28 +14,17 @@
 
 package liquibase.ext.spanner.snapshotgenerator;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.sql.SQLException;
-import javassist.util.proxy.MethodFilter;
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.exception.DatabaseException;
 import liquibase.ext.spanner.ICloudSpanner;
-import liquibase.serializer.LiquibaseSerializable;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.snapshot.JdbcDatabaseSnapshot;
-import liquibase.snapshot.JdbcDatabaseSnapshot.CachingDatabaseMetaData;
-import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.jvm.IndexSnapshotGenerator;
-import liquibase.snapshot.jvm.JdbcSnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
 import liquibase.util.StringUtil;

--- a/src/test/java/liquibase/ext/spanner/JdbcMetadataQueries.java
+++ b/src/test/java/liquibase/ext/spanner/JdbcMetadataQueries.java
@@ -486,18 +486,18 @@ class JdbcMetadataQueries {
     final boolean unique;
     final String name;
     final boolean primaryKey;
-    final int ordinalPosition;
+    final Integer ordinalPosition;
     final String column;
-    final boolean ascending;
+    final Boolean ascending;
 
     IndexMetaData(
         String table,
         boolean unique,
         String name,
         boolean primaryKey,
-        int ordinalPosition,
+        Integer ordinalPosition,
         String column,
-        boolean ascending) {
+        Boolean ascending) {
       this.table = table;
       this.unique = unique;
       this.name = name;
@@ -520,9 +520,13 @@ class JdbcMetadataQueries {
               .addValues(Value.newBuilder().setStringValue(""))
               .addValues(Value.newBuilder().setStringValue(index.name))
               .addValues(Value.newBuilder().setStringValue(index.primaryKey ? "1" : "2"))
-              .addValues(Value.newBuilder().setStringValue(String.valueOf(index.ordinalPosition)))
+              .addValues(index.ordinalPosition == null
+                  ? Value.newBuilder().setNullValue(NullValue.NULL_VALUE)
+                  : Value.newBuilder().setStringValue(String.valueOf(index.ordinalPosition)))
               .addValues(Value.newBuilder().setStringValue(index.column))
-              .addValues(Value.newBuilder().setStringValue(index.ascending ? "A" : "D"))
+              .addValues(index.ascending == null
+                  ? Value.newBuilder().setNullValue(NullValue.NULL_VALUE)
+                  : Value.newBuilder().setStringValue(index.ascending ? "A" : "D"))
               .addValues(Value.newBuilder().setStringValue("-1"))
               .addValues(Value.newBuilder().setStringValue("-1"))
           );


### PR DESCRIPTION
Adds support for taking a snapshot of an index with a STORING column clause. These failed because Liquibase assumes that the ordinal position of a column would always be non-null. In Cloud Spanner, index columns in a STORING clause have a null value for their ordinal position.

Note that the STORING clause is not generated by Liquibase, as Liquibase itself does nothing with that part of an index. This could be added to a custom index generator for Cloud Spanner in a separate PR.

Fixes #159