### PR TITLE
deps: bump emulator version to latest and optimize startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.testcontainers:testcontainers:1.15.3")
-    testImplementation("net.java.dev.jna:jna:5.8.0")
+    testImplementation("org.testcontainers:testcontainers:1.17.6")
+    testImplementation("net.java.dev.jna:jna:5.13.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("com.google.truth:truth:1.0.1")
     testImplementation("org.mockito:mockito-core:1.10.19")

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <gax-grpc.version>2.4.0</gax-grpc.version>
     <jupiter.version>5.6.2</jupiter.version>
-    <testcontainers.version>1.17.5</testcontainers.version>
+    <testcontainers.version>1.17.6</testcontainers.version>
     <truth.version>1.0.1</truth.version>
     <mockito.version>1.10.19</mockito.version>
   </properties>
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.8.0</version>
+      <version>5.13.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/google/spanner/liquibase/TestHarness.java
+++ b/src/test/java/com/google/spanner/liquibase/TestHarness.java
@@ -18,16 +18,11 @@ package com.google.spanner.liquibase;
 
 import com.google.cloud.spanner.*;
 import com.google.cloud.spanner.connection.ConnectionOptions;
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.time.Duration;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -46,11 +41,6 @@ public class TestHarness {
 
     // Stop() stops the test Spanner database and does any needed cleanup.
     void stop() throws SQLException;
-  }
-
-  public static String readResource(String resource) {
-    InputStream is = TestHarness.class.getClassLoader().getResourceAsStream(resource);
-    return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
   }
 
   private static void createInstance(Spanner service, String instanceId) throws SQLException {
@@ -105,7 +95,7 @@ public class TestHarness {
       // Create the database
       service
           .getDatabaseAdminClient()
-          .createDatabase(instanceId, databaseId, Arrays.asList())
+          .createDatabase(instanceId, databaseId, Collections.emptyList())
           .get();
 
     } catch (ExecutionException | InterruptedException e) {

--- a/src/test/java/com/google/spanner/liquibase/TestHarness.java
+++ b/src/test/java/com/google/spanner/liquibase/TestHarness.java
@@ -143,13 +143,12 @@ public class TestHarness {
     if (spannerEmulatorHost == null) {
 
       // Create the container
-      final String SPANNER_EMULATOR_IMAGE = "gcr.io/cloud-spanner-emulator/emulator:1.2.0";
+      final String SPANNER_EMULATOR_IMAGE = "gcr.io/cloud-spanner-emulator/emulator:latest";
       testContainer =
           new GenericContainer<>(SPANNER_EMULATOR_IMAGE)
               .withCommand()
               .withExposedPorts(9010, 9020)
-              .withStartupTimeout(Duration.ofSeconds(10))
-              .waitingFor(Wait.forHttp("/").forStatusCode(404));
+              .waitingFor(Wait.forListeningPort());
 
       // Start the container
       testContainer.start();


### PR DESCRIPTION
Updates the dependencies for testing using the emulator to the latest. This also includes always using the latest version of the emulator for tests. The startup time of the emulator based tests is optmized by adding a wait-for for the listening port of the emulator, instead of relying on a 10 second startup-wait-time and an error being returned for a non-existing URL.