### PR TITLE
deps: update Liquibase test harness to 1.0.9

### DIFF
--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
     <testcontainers.version>1.17.5</testcontainers.version>
     <truth.version>1.0.1</truth.version>
     <mockito.version>1.10.19</mockito.version>
+    <groovy.version>2.4.17</groovy.version>
+    <dependency.spock.version>1.3-groovy-2.4</dependency.spock.version>
   </properties>
 
   <dependencyManagement>
@@ -87,45 +89,47 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
     </dependency>
-    
+
     <!-- Liquibase test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.liquibase</groupId>
-      <artifactId>liquibase-test-harness</artifactId>
-      <version>1.0.5</version>
-      <scope>test</scope>
-    </dependency>
     <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.5.7</version>
+      <version>${groovy.version}</version>
+      <scope>test</scope>
       <type>pom</type>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>
           <artifactId>groovy-testng</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-swing</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
+      <groupId>cglib</groupId>
+      <artifactId>cglib-nodep</artifactId>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.spockframework</groupId>
-      <artifactId>spock-core</artifactId>
-      <version>1.3-groovy-2.5</version>
+    <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>3.3</version>
       <scope>test</scope>
     </dependency>
 
     <!-- Generic test dependencies -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -155,13 +159,7 @@
       <version>${truth.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    
+
     <!-- Spanner test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -281,23 +279,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-          <groupId>org.codehaus.gmavenplus</groupId>
-          <artifactId>gmavenplus-plugin</artifactId>
-          <version>1.12.1</version>
-          <executions>
-              <execution>
-                  <goals>
-                      <goal>addSources</goal>
-                      <goal>addTestSources</goal>
-                      <goal>compile</goal>
-                      <goal>compileTests</goal>
-                      <goal>removeStubs</goal>
-                      <goal>removeTestStubs</goal>
-                  </goals>
-              </execution>
-          </executions>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -373,6 +354,68 @@
           </snapshots>
         </repository>
       </repositories>
+    </profile>
+    <profile>
+      <id>surefire-java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludedGroups>integration</excludedGroups>
+              <excludes>
+                <exclude>**/CloudSpannerHarnessTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>liquibase-test-harness</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <!-- Liquibase test dependencies -->
+        <dependency>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-test-harness</artifactId>
+          <version>1.0.9</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.spockframework</groupId>
+          <artifactId>spock-core</artifactId>
+          <version>${dependency.spock.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <version>1.12.1</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>addSources</goal>
+                  <goal>addTestSources</goal>
+                  <goal>compile</goal>
+                  <goal>compileTests</goal>
+                  <goal>removeStubs</goal>
+                  <goal>removeTestStubs</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Bumps the Liquibase test harness version to 1.0.9 and aligns all other relevant test dependencies with the versions that are required for that. Note that the test harness version 1.0.9 no longer works with Java 8, and requires at least Java 11 to run. This change therefore also adds a build profile that is only activated for Java 8 and that excludes running the Liquibase test harness tests. The tests are run on Java 11 and higher.