### PR TITLE
build: use pinned Ubuntu version for JDK8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   # Only execute unit tests
   execute_unit_tests:
     machine:
-       image: ubuntu-2004:current
+       image: ubuntu-2004:2023.02.1
     steps:
       - checkout
       - run:
@@ -22,7 +22,7 @@ jobs:
   build_and_test:
     machine:
        # Due to test containers
-       image: ubuntu-2004:current
+       image: ubuntu-2004:2023.02.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Use a pinned Unbuntu image version to ensure that we get JDK8.