### PR TITLE
feat: support bit-reversed sequences

### DIFF
--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DropSequenceGeneratorSpanner.java
@@ -22,16 +22,6 @@ import liquibase.sqlgenerator.core.DropSequenceGenerator;
 import liquibase.statement.core.DropSequenceStatement;
 
 public class DropSequenceGeneratorSpanner extends DropSequenceGenerator {
-  static final String DROP_SEQUENCE_VALIDATION_ERROR =
-      "Cloud Spanner does not support dropping sequences";
-
-  @Override
-  public ValidationErrors validate(
-      DropSequenceStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-    ValidationErrors errors = super.validate(statement, database, sqlGeneratorChain);
-    errors.addError(DROP_SEQUENCE_VALIDATION_ERROR);
-    return errors;
-  }
 
   @Override
   public int getPriority() {

--- a/src/test/resources/create-sequence.spanner.yaml
+++ b/src/test/resources/create-sequence.spanner.yaml
@@ -24,6 +24,9 @@ databaseChangeLog:
        - createSequence:
           sequenceName: IdSequence
           startValue:   100000
+          # minValue and maxValue are translated to skip_range_min and skip_range_max
+          minValue:     900000
           maxValue:     999999
           incrementBy:  1
-          cycle:        true
+       - createSequence:
+           sequenceName: MinimalSequence


### PR DESCRIPTION
Adds support for creating and dropping bit-reversed sequences. Renaming a sequence is still not supported.

The minValue and maxValue properties in Liquibase do not have a corresponding property in Cloud Spanner, but at the same time, Cloud Spanner has skip_range_min and skip_range_max, which are not available in Liquibase. The minValue van maxValue properties in Liquibase are therefore mapped to the skip-range values in Cloud Spanner.