### PR TITLE
fix: clearCheckSums generated invalid SQL

### DIFF
--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/DeleteGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/DeleteGeneratorSpanner.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.DeleteGenerator;
+import liquibase.statement.core.DeleteStatement;
+
+public class DeleteGeneratorSpanner extends DeleteGenerator {
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(DeleteStatement statement, Database database) {
+    return database instanceof ICloudSpanner;
+  }
+
+  @Override
+  public Sql[] generateSql(
+      DeleteStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    if (statement.getWhere() == null) {
+      statement.setWhere("true");
+    }
+    return super.generateSql(statement, database, sqlGeneratorChain);
+  }
+
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/UpdateGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/UpdateGeneratorSpanner.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.UpdateGenerator;
+import liquibase.statement.core.UpdateStatement;
+
+public class UpdateGeneratorSpanner extends UpdateGenerator {
+
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+  
+  @Override
+  public boolean supports(UpdateStatement statement, Database database) {
+    return database instanceof ICloudSpanner;
+  }
+
+  @Override
+  public Sql[] generateSql(
+      UpdateStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    if (statement.getWhereClause() == null) {
+      statement.setWhereClause("true");
+    }
+    return super.generateSql(statement, database, sqlGeneratorChain);
+  }
+}

--- a/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
+++ b/src/test/java/com/google/spanner/liquibase/LiquibaseTests.java
@@ -923,7 +923,6 @@ public class LiquibaseTests {
     return false;
   }
 
-  @Disabled("The emulator does not yet support VIEWs")
   @Test
   void doEmulatorCreateViewTest() throws Exception {
     doCreateViewTest(getSpannerEmulator());
@@ -963,9 +962,10 @@ public class LiquibaseTests {
         try {
           Liquibase liquibase =
               getLiquibase(testHarness, "create-or-replace-view.spanner.yaml");
+          liquibase.clearCheckSums();
           liquibase.update(new Contexts("test"));
 
-          try (ResultSet rs = statement.executeQuery("SELECT * FROM V_Singers")) {
+          try (ResultSet rs = statement.executeQuery("SELECT * FROM V_Singers ORDER BY LastName")) {
             for (char prefix : prefixes) {
               assertThat(rs.next()).isTrue();
               assertThat(rs.getString("LastName"))

--- a/src/test/java/liquibase/ext/spanner/SqlTest.java
+++ b/src/test/java/liquibase/ext/spanner/SqlTest.java
@@ -44,6 +44,7 @@ public class SqlTest extends AbstractMockServerTest {
   
   @BeforeAll
   static void setupResults() {
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of("UPDATE DATABASECHANGELOG SET MD5SUM = NULL WHERE true"), 0L));
     mockSpanner.putStatementResult(StatementResult.update(Statement.of(INSERT1), 1L));
     mockSpanner.putStatementResult(StatementResult.update(Statement.of(INSERT2), 1L));
   }
@@ -59,6 +60,7 @@ public class SqlTest extends AbstractMockServerTest {
     for (String file : new String[] {"sql.yaml"}) {
       try (Connection con = createConnection();
           Liquibase liquibase = getLiquibase(con, file)) {
+        liquibase.clearCheckSums();
         liquibase.update(new Contexts("test"));
       }
     }


### PR DESCRIPTION
Spanner requires that all UPDATE and DELETE statements contain a WHERE clause as safety precaution against accidental updates and deletes. Liquibase however by default generates UPDATE and DELETE statements without a WHERE clause if none has been specified. The Spanner Liquibase provider therefore now adds custom generators for those statements that automatically add a `WHERE true` clause to statements that do not have a WHERE clause.

The `clear-checksums` command (https://docs.liquibase.com/commands/utility/clear-checksums.html) generated such an update statement, and would therefore fail with an error like this:

```
INVALID_ARGUMENT: com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException:  
INVALID_ARGUMENT: UPDATE must have a WHERE clause [at 1:1]
UPDATE DATABASECHANGELOG SET MD5SUM = NULL
```