### PR TITLE
Add Support for Sequences in Liquibase Cloud Spanner Extension

### DIFF
--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -174,7 +174,7 @@ public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner 
 
   @Override
   public boolean supportsSequences() {
-    return false;
+    return true;
   }
 
   @Override

--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/SequenceSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/SequenceSnapshotGeneratorSpanner.java
@@ -1,0 +1,74 @@
+package liquibase.ext.spanner.snapshotgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.snapshot.SnapshotGenerator;
+import liquibase.snapshot.jvm.SequenceSnapshotGenerator;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawParameterizedSqlStatement;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.ForeignKey;
+import liquibase.structure.core.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SequenceSnapshotGeneratorSpanner extends SequenceSnapshotGenerator {
+
+  /**
+   * This generator will be in all chains relating to CloudSpanner, whether or not
+   * the objectType is {@link liquibase.structure.core.Sequence}.
+   */
+  @Override
+  public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+    if (database instanceof ICloudSpanner) {
+      return PRIORITY_DATABASE;
+    }
+    return PRIORITY_NONE;
+  }
+
+  @Override
+  protected SqlStatement getSelectSequenceStatement(Schema schema, Database database) {
+    if (database instanceof ICloudSpanner) {
+      List<String> parameter = new ArrayList<>(2);
+      parameter.add(database.getDefaultCatalogName());
+      parameter.add(database.getDefaultSchemaName());
+
+      StringBuilder sql = new StringBuilder("SELECT seq.NAME AS SEQUENCE_NAME, ")
+                              .append("seq_kind.OPTION_VALUE AS SEQUENCE_KIND, ")
+                              .append("skip_max.OPTION_VALUE AS SKIP_RANGE_MAX, ")
+                              .append("skip_min.OPTION_VALUE AS SKIP_RANGE_MIN, ")
+                              .append("start_counter.OPTION_VALUE AS START_VALUE ")
+                              .append("FROM (SELECT DISTINCT NAME ")
+                              .append("FROM INFORMATION_SCHEMA.sequence_options ")
+                              .append("WHERE CATALOG = ? AND SCHEMA = ?) AS seq ")
+                              .append("LEFT JOIN INFORMATION_SCHEMA.sequence_options AS seq_kind ")
+                              .append("ON seq.NAME = seq_kind.NAME ")
+                              .append("AND seq_kind.OPTION_NAME = 'sequence_kind' ")
+                              .append("LEFT JOIN INFORMATION_SCHEMA.sequence_options AS skip_max ")
+                              .append("ON seq.NAME = skip_max.NAME ")
+                              .append("AND skip_max.OPTION_NAME = 'skip_range_max' ")
+                              .append("LEFT JOIN INFORMATION_SCHEMA.sequence_options AS skip_min ")
+                              .append("ON seq.NAME = skip_min.NAME ")
+                              .append("AND skip_min.OPTION_NAME = 'skip_range_min' ")
+                              .append("LEFT JOIN INFORMATION_SCHEMA.sequence_options AS start_counter ")
+                              .append("ON seq.NAME = start_counter.NAME ")
+                              .append("AND start_counter.OPTION_NAME = 'start_with_counter';");
+
+
+      return new RawParameterizedSqlStatement(sql.toString(), parameter.toArray());
+    }
+    return super.getSelectSequenceStatement(schema, database);
+  }
+
+  /*
+   * If there is a UniqueConstraintSnapshotGenerator in the chain, we replace it. Otherwise
+   * the chain will execute like normal.
+   */
+  @Override
+  public Class<? extends SnapshotGenerator>[] replaces() {
+    return new Class[]{SequenceSnapshotGenerator.class};
+  }
+
+  ;
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/AlterSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/AlterSequenceGeneratorSpanner.java
@@ -1,0 +1,33 @@
+package liquibase.ext.spanner.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.ext.spanner.ICloudSpanner;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AlterSequenceGenerator;
+import liquibase.statement.core.AlterSequenceStatement;
+import liquibase.statement.core.RenameSequenceStatement;
+
+public class AlterSequenceGeneratorSpanner extends AlterSequenceGenerator {
+  static final String ALTER_SEQUENCE_VALIDATION_ERROR =
+      "The Liquibase Cloud Spanner extension does not support altering sequences from XML. Please use SQL to create the change instead.";
+
+  @Override
+  public ValidationErrors validate(
+      AlterSequenceStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    ValidationErrors errors = super.validate(statement, database, sqlGeneratorChain);
+    errors.addError(ALTER_SEQUENCE_VALIDATION_ERROR);
+    return errors;
+  }
+
+  @Override
+  public int getPriority() {
+    return SqlGenerator.PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(AlterSequenceStatement statement, Database database) {
+    return (database instanceof ICloudSpanner);
+  }
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateSequenceGeneratorSpanner.java
@@ -36,12 +36,10 @@ public class CreateSequenceGeneratorSpanner extends CreateSequenceGenerator {
     errors.checkDisallowedField("ordered", statement.getOrdered(), database, CloudSpanner.class);
     errors.checkDisallowedField("cycle", statement.getCycle(), database, CloudSpanner.class);
     errors.checkDisallowedField("dataType", statement.getDataType(), database, CloudSpanner.class);
-    // Allow setting incrementBy to 1.
-    if (!Objects.equals(BigInteger.ONE, statement.getIncrementBy())) {
-      errors.checkDisallowedField("incrementBy", statement.getIncrementBy(), database,
-          CloudSpanner.class);
-    }
-    
+    errors.checkDisallowedField("incrementBy", statement.getDataType(), database, CloudSpanner.class);
+    errors.checkDisallowedField("minValue", statement.getDataType(), database, CloudSpanner.class);
+    errors.checkDisallowedField("cacheSize", statement.getDataType(), database, CloudSpanner.class);
+    errors.checkDisallowedField("maxValue", statement.getDataType(), database, CloudSpanner.class);
     return errors;
   }
 
@@ -52,12 +50,6 @@ public class CreateSequenceGeneratorSpanner extends CreateSequenceGenerator {
     queryStringBuilder.append("CREATE SEQUENCE ");
     queryStringBuilder.append(database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), statement.getSequenceName()));
     queryStringBuilder.append(" OPTIONS (sequence_kind='bit_reversed_positive'");
-    if (statement.getMinValue() != null) {
-      queryStringBuilder.append(", skip_range_min = ").append(statement.getMinValue());
-    }
-    if (statement.getMaxValue() != null) {
-      queryStringBuilder.append(", skip_range_max = ").append(statement.getMaxValue());
-    }
     if (statement.getStartValue() != null) {
       queryStringBuilder.append(", start_with_counter = ").append(statement.getStartValue());
     }

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/AlterSequenceTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/AlterSequenceTest.java
@@ -1,0 +1,42 @@
+package liquibase.ext.spanner.sqlgenerator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.exception.CommandExecutionException;
+import liquibase.ext.spanner.AbstractMockServerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.OutputStreamWriter;
+import java.sql.Connection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class AlterSequenceTest extends AbstractMockServerTest {
+
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testAlterSequenceFromYaml() throws Exception {
+    for (String file : new String[]{"alter-sequence.spanner.yaml"}) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
+        CommandExecutionException exception = assertThrows(CommandExecutionException.class,
+            () -> liquibase.update(new Contexts("test"), new OutputStreamWriter(System.out)));
+        assertThat(exception.getMessage()).contains(
+            AlterSequenceGeneratorSpanner.ALTER_SEQUENCE_VALIDATION_ERROR);
+      }
+    }
+    assertThat(mockAdmin.getRequests()).isEmpty();
+  }
+}

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDropSequenceTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDropSequenceTest.java
@@ -43,8 +43,6 @@ public class CreateDropSequenceTest extends AbstractMockServerTest {
   void testCreateSequenceFromYaml() throws Exception {
     ImmutableList<String> expectedSql = ImmutableList.of("CREATE SEQUENCE IdSequence " 
         + "OPTIONS (sequence_kind='bit_reversed_positive', "
-        + "skip_range_min = 900000, "
-        + "skip_range_max = 999999, " 
         + "start_with_counter = 100000)",
         "CREATE SEQUENCE MinimalSequence OPTIONS (sequence_kind='bit_reversed_positive')");
     addUpdateDdlStatementsResponse(expectedSql.get(0));

--- a/src/test/resources/alter-sequence.spanner.yaml
+++ b/src/test/resources/alter-sequence.spanner.yaml
@@ -15,14 +15,19 @@
 
 databaseChangeLog:
   - preConditions:
-     onFail: HALT
-     onError: HALT
+      onFail: HALT
+      onError: HALT
   - changeSet:
-     id:     v0.1-create-sequence
-     author: spanner-liquibase-tests
-     changes:
-       - createSequence:
-          sequenceName: IdSequence
-          startValue:   100000
-       - createSequence:
-           sequenceName: MinimalSequence
+      id: v0.1-create-sequence
+      author: spanner-liquibase-tests
+      changes:
+          - createSequence:
+              sequenceName: test_sequence_name
+              startValue: 100
+  - changeSet:
+      id: v0.2-alter-sequence
+      author: spanner-liquibase-tests
+      changes:
+          - alterSequence:
+              sequenceName: test_sequence_name
+              startValue: 1000000

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/alterSequence.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/alterSequence.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="spanner-liquibase-tests">
+        <createSequence sequenceName="test_sequence"
+                        startValue="10"/>
+        <rollback>
+            <dropSequence sequenceName="test_sequence"/>
+        </rollback>
+    </changeSet>
+    <changeSet author="spanner-liquibase-tests" id="2" >
+       <sql>
+           ALTER SEQUENCE test_sequence SET OPTIONS (skip_range_min = 1000, skip_range_max = 5000000)
+       </sql>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createSequence.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createSequence.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="spanner-liquibase-tests" id="1">
+        <createSequence sequenceName="test_sequence"
+                        startValue="100"/>
+        <rollback>
+            <dropSequence sequenceName="test_sequence"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/dropSequence.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/dropSequence.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="spanner-liquibase-tests" id="1">
+        <createSequence sequenceName="test_sequence"
+                        startValue="1"/>
+        <dropSequence sequenceName="test_sequence"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/alterSequence.json
+++ b/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/alterSequence.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Sequence": [
+        {
+          "sequence": {
+            "name": "test_sequence",
+            "startValue": "10\\!\\{java.math.BigInteger\\}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/createSequence.json
+++ b/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/createSequence.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Sequence": [
+        {
+          "sequence": {
+            "name": "test_sequence",
+            "startValue": "100\\!\\{java.math.BigInteger\\}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/alterSequence.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/alterSequence.sql
@@ -1,1 +1,2 @@
-INVALID TEST  -- Not supported in the current version of the Cloud Spanner extension; it will be added in future releases.
+CREATE SEQUENCE test_sequence OPTIONS (sequence_kind='bit_reversed_positive', start_with_counter = 10)
+ALTER SEQUENCE test_sequence SET OPTIONS (skip_range_min = 1000, skip_range_max = 5000000)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createSequence.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createSequence.sql
@@ -1,1 +1,1 @@
-INVALID TEST -- Not supported in the current version of the Cloud Spanner extension; it will be added in future releases.
+CREATE SEQUENCE test_sequence OPTIONS (sequence_kind='bit_reversed_positive', start_with_counter = 100)

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropSequence.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/dropSequence.sql
@@ -1,1 +1,2 @@
-INVALID TEST -- CloudSpanner doesn't support sequences
+CREATE SEQUENCE test_sequence OPTIONS (sequence_kind='bit_reversed_positive', start_with_counter = 1)
+DROP SEQUENCE test_sequence


### PR DESCRIPTION
This PR introduces support for creating and managing sequences in the Liquibase Cloud Spanner extension. Key changes include:
This PR introduces support for creating and managing sequences in the Liquibase Cloud Spanner extension. Key changes include:
-  Implementation of sequence creation and handling logic.
- Adjustments to support sequence-related operations using SQL.
- Additional tests to ensure the proper functionality of sequence operations.

Limitations:
- Altering sequences is supported only via SQL, not through XML or YAML changelogs.
- The sequence_kind, skip_range_max, and skip_range_min properties are not supported in XML or YAML changelogs; they can only be used via SQL.
- For start_with_counter, you need to use the startValue parameter in the changelog.