### PR TITLE
test: add test for Generated Column in Liquibase Changelog

### DIFF
--- a/src/test/java/liquibase/ext/spanner/CreateTableWithGeneratedColumns.java
+++ b/src/test/java/liquibase/ext/spanner/CreateTableWithGeneratedColumns.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package liquibase.ext.spanner;
+
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.sql.Connection;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+public class CreateTableWithGeneratedColumns extends AbstractMockServerTest {
+  @BeforeEach
+  void resetServer() {
+    mockSpanner.reset();
+    mockAdmin.reset();
+  }
+
+  @Test
+  void testCreateTableWithGeneratedColumnFromYaml() throws Exception {
+    String[] expectedSql =
+        new String[] {
+            "CREATE TABLE table_test_generated_column (id INT64 NOT NULL, FirstName STRING(200), LastName STRING(200), FullName STRING(400) AS (FirstName || ' ' || LastName) STORED) PRIMARY KEY (id)"
+            };
+    for (String sql : expectedSql) {
+      addUpdateDdlStatementsResponse(sql);
+    }
+
+    for (String file : new String[] {"create-table-with-generated-column.spanner.yaml"}) {
+      try (Connection con = createConnection(); Liquibase liquibase = getLiquibase(con, file)) {
+        // Update to version v0.1.
+        liquibase.update(new Contexts("test"), new LabelExpression("version 0.1"));
+      }
+    }
+    for (int i = 0; i < expectedSql.length; i++) {
+      assertThat(mockAdmin.getRequests().get(i)).isInstanceOf(UpdateDatabaseDdlRequest.class);
+      UpdateDatabaseDdlRequest request = (UpdateDatabaseDdlRequest) mockAdmin.getRequests().get(i);
+      assertThat(request.getStatementsList()).hasSize(1);
+      assertThat(request.getStatementsList().get(0)).isEqualTo(expectedSql[i]);
+    }
+  }
+}

--- a/src/test/resources/create-table-with-generated-column.spanner.yaml
+++ b/src/test/resources/create-table-with-generated-column.spanner.yaml
@@ -1,0 +1,42 @@
+#Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+databaseChangeLog:
+  - preConditions:
+      onFail: HALT
+      onError: HALT
+  - changeSet:
+      id: v0.1-create-table-with-computed-column
+      labels: version 0.1
+      author: spanner-liquibase-tests
+      changes:
+        - createTable:
+            tableName: table_test_generated_column
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: FirstName
+                  type: STRING(200)
+              - column:
+                  name: LastName
+                  type: STRING(200)
+              - column:
+                  name: FullName STRING(400) AS (FirstName || ' ' || LastName) STORED
+                  computed: true

--- a/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createTableWithGeneratedColumn.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/cloudspanner/createTableWithGeneratedColumn.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="1" author="spanner-liquibase-tests">
+        <createTable tableName="table_test_generated_column">
+            <column name="id" type="BIGINT">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="FirstName" type="STRING(200)"/>
+            <column name="LastName" type="STRING(200)"/>
+            <column name="FullName STRING(400) AS (FirstName || ' ' || LastName) STORED"
+                    computed="true"/>
+        </createTable>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/createTableWithGeneratedColumn.json
+++ b/src/test/resources/liquibase/harness/change/expectedSnapshot/cloudspanner/createTableWithGeneratedColumn.json
@@ -1,0 +1,16 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "FullName",
+            "type": {
+              "typeName": "STRING(400)"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTableWithGeneratedColumn.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/cloudspanner/createTableWithGeneratedColumn.sql
@@ -1,0 +1,1 @@
+CREATE TABLE table_test_generated_column (id INT64 NOT NULL, FirstName STRING(200), LastName STRING(200), FullName STRING(400) AS (FirstName || ' ' || LastName) STORED) PRIMARY KEY (id)


### PR DESCRIPTION
This PR introduces a test for generated (computed) columns in Liquibase changelogs.
Added a test to verify the correct handling of computed columns.
Using for computed="true" and Type in the changelog.
Ensured the generated SQL correctly reflects the computed column definition.
