### PR TITLE
chore: register a default mock result for column defaults

### DIFF
--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/ColumnSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/ColumnSnapshotGeneratorSpanner.java
@@ -40,6 +40,7 @@ public class ColumnSnapshotGeneratorSpanner extends ColumnSnapshotGenerator {
       CachedRow columnMetadataResultSet, Column columnInfo, Database database) {
     if (database instanceof ICloudSpanner) {
       try {
+        // TODO: Remove when COLUMN_DEF is included in the results for getColumns
         String selectQuery =
             "SELECT DISTINCT COLUMN_DEFAULT AS COLUMN_DEF FROM INFORMATION_SCHEMA.COLUMNS "
                 + "WHERE TABLE_CATALOG = ? "


### PR DESCRIPTION
The Spanner Liquibase provider executes an extra query to get the column default value, as the Spanner JDBC driver does not include that in the metadata it returns.

This will be fixed in https://github.com/googleapis/java-spanner-jdbc/pull/1937