### PR TITLE
chore: add getDialect() method

### DIFF
--- a/src/main/java/liquibase/ext/spanner/CloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/CloudSpanner.java
@@ -142,9 +142,9 @@ public class CloudSpanner extends AbstractJdbcDatabase implements ICloudSpanner 
     // even if the connection was not replaced it would have been closed by Liquibase at the same
     // moment.
     if (!(conn instanceof CloudSpannerConnection)
-            && conn instanceof JdbcConnection
-            && ((JdbcConnection) conn).getUnderlyingConnection()
-                   instanceof CloudSpannerJdbcConnection) {
+        && conn instanceof JdbcConnection
+        && ((JdbcConnection) conn).getUnderlyingConnection()
+            instanceof CloudSpannerJdbcConnection) {
       // The underlying connection is a Spanner JDBC connection. Check whether it already included a
       // user-agent string.
       if (!conn.getURL().contains("userAgent=")) {

--- a/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
@@ -1,9 +1,8 @@
 package liquibase.ext.spanner;
 
 import com.google.cloud.spanner.Dialect;
-import liquibase.database.Database;
-
 import java.sql.SQLException;
+import liquibase.database.Database;
 
 public interface ICloudSpanner extends Database {
   Dialect getDialect() throws SQLException;

--- a/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/ICloudSpanner.java
@@ -1,5 +1,10 @@
 package liquibase.ext.spanner;
 
+import com.google.cloud.spanner.Dialect;
 import liquibase.database.Database;
 
-public interface ICloudSpanner extends Database {}
+import java.sql.SQLException;
+
+public interface ICloudSpanner extends Database {
+  Dialect getDialect() throws SQLException;
+}

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpanner.java
@@ -14,6 +14,7 @@
 package liquibase.ext.spanner.sqlgenerator;
 
 import com.google.cloud.spanner.Dialect;
+import java.sql.SQLException;
 import liquibase.database.Database;
 import liquibase.ext.spanner.ICloudSpanner;
 import liquibase.sql.Sql;
@@ -21,8 +22,6 @@ import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateDatabaseChangeLogLockTableGenerator;
 import liquibase.statement.core.CreateDatabaseChangeLogLockTableStatement;
-
-import java.sql.SQLException;
 
 public class CreateDatabaseChangeLogLockTableGeneratorSpanner
     extends CreateDatabaseChangeLogLockTableGenerator {

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpanner.java
@@ -43,7 +43,7 @@ public class CreateDatabaseChangeLogLockTableGeneratorSpanner
           + "    id          bigint primary key,\n"
           + "    locked      bool,\n"
           + "    lockgranted timestamptz,\n"
-          + "    lockedby    varchar(255)\n"
+          + "    lockedby    varchar,\n"
           + ")";
 
   @Override
@@ -59,16 +59,10 @@ public class CreateDatabaseChangeLogLockTableGeneratorSpanner
       throw new RuntimeException(e);
     }
     String databaseChangeLogLockTableName = getDatabaseChangeLogLockTableNameFrom(database);
-    String createTableSQL = "";
-    if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
-      createTableSQL =
-          this.createTableSQL.replaceAll(
-              "__DATABASECHANGELOGLOCK__", databaseChangeLogLockTableName);
-    } else if (dialect == Dialect.POSTGRESQL) {
-      createTableSQL =
-          this.createPostgresqlTableSQL.replaceAll(
-              "__DATABASECHANGELOGLOCK__", databaseChangeLogLockTableName);
-    }
+    String createTableSQL =
+        dialect == Dialect.POSTGRESQL ? this.createPostgresqlTableSQL : this.createTableSQL;
+    createTableSQL =
+        createTableSQL.replaceAll("__DATABASECHANGELOGLOCK__", databaseChangeLogLockTableName);
 
     return new Sql[] {new UnparsedSql(createTableSQL)};
   }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
@@ -27,7 +27,7 @@ import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
 public class CreateDatabaseChangeLogTableGeneratorSpanner
     extends CreateDatabaseChangeLogTableGenerator {
 
-  final String createTableSql =
+  final String createTableSQL =
       ""
           + "CREATE TABLE __DATABASECHANGELOG__\n"
           + "(\n"
@@ -47,24 +47,24 @@ public class CreateDatabaseChangeLogTableGeneratorSpanner
           + "    deployment_id string(MAX),\n"
           + ") primary key (id, author, filename);";
 
-  final String createPostgresqlTableSql =
+  final String createPostgresqlTableSQL =
       ""
           + "CREATE TABLE public.__DATABASECHANGELOG__\n"
           + "(\n"
-          + "    id            varchar(255) not null,\n"
-          + "    author        varchar(255) not null,\n"
-          + "    filename      varchar(255) not null,\n"
+          + "    id            varchar not null,\n"
+          + "    author        varchar not null,\n"
+          + "    filename      varchar not null,\n"
           + "    dateExecuted  timestamptz  not null,\n"
           + "    orderExecuted bigint       not null,\n"
-          + "    execType      varchar(255),\n"
-          + "    md5sum        varchar(255),\n"
-          + "    description   varchar(255),\n"
-          + "    comments      varchar(255),\n"
-          + "    tag           varchar(255),\n"
-          + "    liquibase     varchar(255),\n"
-          + "    contexts      varchar(255),\n"
-          + "    labels        varchar(255),\n"
-          + "    deployment_id varchar(255),\n"
+          + "    execType      varchar,\n"
+          + "    md5sum        varchar,\n"
+          + "    description   varchar,\n"
+          + "    comments      varchar,\n"
+          + "    tag           varchar,\n"
+          + "    liquibase     varchar,\n"
+          + "    contexts      varchar,\n"
+          + "    labels        varchar,\n"
+          + "    deployment_id varchar,\n"
           + "    PRIMARY KEY (id, author, filename)\n"
           + ");";
 
@@ -94,16 +94,9 @@ public class CreateDatabaseChangeLogTableGeneratorSpanner
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
-
-    String createTableSQL = "";
-    if (dialect == Dialect.GOOGLE_STANDARD_SQL) {
-      createTableSQL =
-          this.createTableSql.replaceAll("__DATABASECHANGELOG__", databaseChangeLogTableName);
-    } else if (dialect == Dialect.POSTGRESQL) {
-      createTableSQL =
-          this.createPostgresqlTableSql.replaceAll(
-              "__DATABASECHANGELOG__", databaseChangeLogTableName);
-    }
+    String createTableSQL =
+        dialect == Dialect.POSTGRESQL ? this.createPostgresqlTableSQL : this.createTableSQL;
+    createTableSQL = createTableSQL.replaceAll("__DATABASECHANGELOG__", databaseChangeLogTableName);
 
     return new Sql[] {new UnparsedSql(createTableSQL)};
   }

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
@@ -14,6 +14,7 @@
 package liquibase.ext.spanner.sqlgenerator;
 
 import com.google.cloud.spanner.Dialect;
+import java.sql.SQLException;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.ext.spanner.ICloudSpanner;
@@ -22,8 +23,6 @@ import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGenerator;
 import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
-
-import java.sql.SQLException;
 
 public class CreateDatabaseChangeLogTableGeneratorSpanner
     extends CreateDatabaseChangeLogTableGenerator {

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpannerTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogLockTableGeneratorSpannerTest.java
@@ -16,7 +16,8 @@ package liquibase.ext.spanner.sqlgenerator;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import liquibase.database.Database;
+import java.sql.SQLException;
+import liquibase.ext.spanner.CloudSpanner;
 import liquibase.sql.Sql;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,14 +27,16 @@ class CreateDatabaseChangeLogLockTableGeneratorSpannerTest {
   private static final String DEFAULT_CHANGELOGLOCK = "DATABASECHANGELOGLOCK";
   private static final String CUSTOM_CHANGELOGLOCK = "customChangeLogLock";
 
-  private Database database = Mockito.mock(Database.class);
+  private CloudSpanner database = Mockito.mock(CloudSpanner.class);
 
   private final CreateDatabaseChangeLogLockTableGeneratorSpanner generator =
       new CreateDatabaseChangeLogLockTableGeneratorSpanner();
 
+  // TODO: add tests for PostgreSQL dialect
   @Test
-  public void shouldUseConfiguredDatabaseChangeLogLockTableName() {
+  public void shouldUseConfiguredDatabaseChangeLogLockTableName() throws SQLException {
     givenDatabaseChangeLogLockTableNameIs(CUSTOM_CHANGELOGLOCK);
+    when(database.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
 
     Sql[] sql = generator.generateSql(null, database, null);
 
@@ -41,8 +44,9 @@ class CreateDatabaseChangeLogLockTableGeneratorSpannerTest {
   }
 
   @Test
-  public void shouldUseDefaultDatabaseChangeLogTableNameIfNotConfigured() {
+  public void shouldUseDefaultDatabaseChangeLogTableNameIfNotConfigured() throws SQLException {
     givenDatabaseChangeLogLockTableNameIs(null);
+    when(database.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
 
     Sql[] sql = generator.generateSql(null, database, null);
 

--- a/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpannerTest.java
+++ b/src/test/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpannerTest.java
@@ -16,7 +16,8 @@ package liquibase.ext.spanner.sqlgenerator;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import liquibase.database.Database;
+import java.sql.SQLException;
+import liquibase.ext.spanner.CloudSpanner;
 import liquibase.sql.Sql;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,14 +27,16 @@ class CreateDatabaseChangeLogTableGeneratorSpannerTest {
   private static final String DEFAULT_CHANGELOG = "DATABASECHANGELOG";
   private static final String CUSTOM_CHANGELOG = "customChangeLog";
 
-  private Database database = Mockito.mock(Database.class);
+  private final CloudSpanner database = Mockito.mock(CloudSpanner.class);
 
   private final CreateDatabaseChangeLogTableGeneratorSpanner generator =
       new CreateDatabaseChangeLogTableGeneratorSpanner();
 
+  // TODO: add tests for PostgreSQL dialect
   @Test
-  public void shouldUseConfiguredDatabaseChangeLogTableName() {
+  public void shouldUseConfiguredDatabaseChangeLogTableName() throws SQLException {
     givenDatabaseChangeLogTableNameIs(CUSTOM_CHANGELOG);
+    when(database.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
 
     Sql[] sql = generator.generateSql(null, database, null);
 
@@ -41,8 +44,9 @@ class CreateDatabaseChangeLogTableGeneratorSpannerTest {
   }
 
   @Test
-  public void shouldUseDefaultDatabaseChangeLogTableNameIfNotConfigured() {
+  public void shouldUseDefaultDatabaseChangeLogTableNameIfNotConfigured() throws SQLException {
     givenDatabaseChangeLogTableNameIs(null);
+    when(database.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
 
     Sql[] sql = generator.generateSql(null, database, null);
 


### PR DESCRIPTION
This PR introduces the getDialect() method to both SpannerDatabase and PostgreSqlSpannerDatabase implementations, enabling dialect-aware SQL generation and feature toggling.

Changes:
Implemented getDialect() method returning GOOGLE_STANDARD_SQL or POSTGRESQL as appropriate

Updated related logic to retrieve dialect in SQL generators and changelog handlers

Implement create system Liquibase tables for both dialect  support

