### PR TITLE
fix: remove trailing semicolon in create table databasechangelog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.57.0</version>
+        <version>26.60.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/sqlgenerator/CreateDatabaseChangeLogTableGeneratorSpanner.java
@@ -43,7 +43,7 @@ public class CreateDatabaseChangeLogTableGeneratorSpanner
           + "    contexts      string(MAX),\n"
           + "    labels        string(MAX),\n"
           + "    deployment_id string(MAX),\n"
-          + ") primary key (id, author, filename);";
+          + ") primary key (id, author, filename)";
 
   @Override
   public boolean supports(CreateDatabaseChangeLogTableStatement statement, Database database) {


### PR DESCRIPTION
Spanner does not allow trailing semicolons in DDL statements. Previously, these were automatically
removed by the Spanner client library. This is no longer the case, so we need to remove it from
the Liquibase code for this to work with the latest Spanner client.

Fixes #481