### PR TITLE
fix: Spanner index snapshot generator should replace built-in

### DIFF
--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/ForeignKeySnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/ForeignKeySnapshotGeneratorSpanner.java
@@ -56,5 +56,5 @@ public class ForeignKeySnapshotGeneratorSpanner extends ForeignKeySnapshotGenera
   @Override
   public Class<? extends SnapshotGenerator>[] replaces() {
     return new Class[] {ForeignKeySnapshotGenerator.class};
-  };
+  }
 }

--- a/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
+++ b/src/main/java/liquibase/ext/spanner/snapshotgenerator/IndexSnapshotGeneratorSpanner.java
@@ -28,6 +28,7 @@ import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.snapshot.JdbcDatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.IndexSnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
@@ -216,5 +217,10 @@ public class IndexSnapshotGeneratorSpanner extends IndexSnapshotGenerator {
       }
       return null;
     }
+  }
+
+  @Override
+  public Class<? extends SnapshotGenerator>[] replaces() {
+    return new Class[] {IndexSnapshotGenerator.class};
   }
 }


### PR DESCRIPTION
The Spanner index snapshot generator should replace the built-in generator from Liquibase. This ensures that the Spanner generator is used for all indices.